### PR TITLE
feat: no TLS without necessary config

### DIFF
--- a/src/common/helpers/fetcher.js
+++ b/src/common/helpers/fetcher.js
@@ -15,17 +15,23 @@ export default {
   decodeBase64,
   get fetch () {
     if (!client) {
-      const tls = {
-        key: decodeBase64(config.get('kitsConnection.key')),
-        cert: decodeBase64(config.get('kitsConnection.cert')),
-        rejectUnauthorized: false,
-        servername: config.get('kitsConnection.host')
-      }
       const kitsURL = new URL(config.get('kitsConnection.path'), `https://${config.get('kitsConnection.host')}`)
       kitsURL.port = config.get('kitsConnection.port')
+      logger.info(`Creating new client for ${kitsURL.href}`)
 
-      logger.info(`Creating new client for ${kitsURL.href} with tls options: ${JSON.stringify(tls)}`)
-      client = new Client(kitsURL.href, { connect: tls })
+      if (config.get('kitsConnection.key') && config.get('kitsConnection.cert')) {
+        const tls = {
+          key: decodeBase64(config.get('kitsConnection.key')),
+          cert: decodeBase64(config.get('kitsConnection.cert')),
+          rejectUnauthorized: false,
+          servername: config.get('kitsConnection.host')
+        }
+        logger.info('KITS TLS configuration:')
+        logger.info(tls)
+        client = new Client(kitsURL.href, { connect: tls })
+      } else {
+        client = new Client(kitsURL.href)
+      }
     }
 
     return fetch

--- a/src/common/helpers/logging/logger-options.js
+++ b/src/common/helpers/logging/logger-options.js
@@ -18,7 +18,7 @@ const formatters = {
 
 export const loggerOptions = {
   enabled: logConfig.enabled,
-  // ignorePaths: ['/health'],
+  ignorePaths: ['/health'],
   redact: {
     paths: logConfig.redact,
     censor: (value, path) => {

--- a/src/config.js
+++ b/src/config.js
@@ -89,7 +89,9 @@ const config = convict({
         'req.headers.cookie',
         'res.headers',
         'kitsConnection.key',
-        'kitsConnection.cert'
+        'kitsConnection.cert',
+        'key',
+        'cert'
       ]
     }
   },

--- a/src/routes/get-business.js
+++ b/src/routes/get-business.js
@@ -8,7 +8,7 @@ const getBusiness = {
   path: '/get-business/{id}',
   handler: async (request, h) => {
     logger.info(`GET /get-business with params: ${JSON.stringify(request.params)}`)
-    const result = await fetcher.fetch(`organisation/${request.params.id}`)
+    const result = await fetcher.fetch(`/organisation/${request.params.id}`)
     const { name, sbi, orgId } = result.body
 
     logger.info(`business object with keys: ${Object.keys(result.body)}`)

--- a/src/routes/get-business.test.js
+++ b/src/routes/get-business.test.js
@@ -38,7 +38,7 @@ describe('getBusiness route', () => {
     await getBusiness.handler(request, h)
 
     expect(mockInfo).toHaveBeenCalledWith('GET /get-business with params: {"id":"12345"}')
-    expect(fetcher.fetch).toHaveBeenCalledWith('organisation/12345')
+    expect(fetcher.fetch).toHaveBeenCalledWith('/organisation/12345')
     expect(mockInfo).toHaveBeenCalledWith('business object with keys: name,sbi,orgId,someOther')
     expect(h.response).toHaveBeenCalledWith({ name: 'Test Org', sbi: '67890', orgId: '12345' })
   })
@@ -49,6 +49,6 @@ describe('getBusiness route', () => {
     await expect(getBusiness.handler(request, h)).rejects.toThrow(new Error('some error'))
 
     expect(mockInfo).toHaveBeenCalledWith('GET /get-business with params: {"id":"12345"}')
-    expect(fetcher.fetch).toHaveBeenCalledWith('organisation/12345')
+    expect(fetcher.fetch).toHaveBeenCalledWith('/organisation/12345')
   })
 })


### PR DESCRIPTION
- do not try to add TLS connection options without config
- remove the `/health` route from the HTTP auto-logger
- add `key` and `cert` to the default log redaction list