### PR TITLE
WIP: test: local mTLS connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 .cache
 # cspell:disable-next-line 
 .eslintcache
+test/acceptance/mtls

--- a/test/acceptance/api.ruraldev-mock.js
+++ b/test/acceptance/api.ruraldev-mock.js
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs'
+import { createServer } from 'node:https'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Client } from 'undici'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const serverOptions = {
+  ca: [
+    readFileSync(join(__dirname, './mtls/ca.crt'), 'utf8')
+  ],
+  key: readFileSync(join(__dirname, './mtls/server.key'), 'utf8'),
+  cert: readFileSync(join(__dirname, './mtls/server.crt'), 'utf8'),
+  requestCert: true,
+  rejectUnauthorized: false
+}
+
+const server = createServer(serverOptions, (req, res) => {
+  console.log('handling request...')
+  // true if client cert is valid
+  if (req.client.authorized === true) {
+    console.log('valid')
+  } else {
+    console.error('cert error:', req.client.authorizationError)
+    res.statusCode = 401
+  }
+  res.write(JSON.stringify({ status: req.client.authorizationError || 'ok' }), () => res.end())
+})
+
+server.listen(0, 'localhost', function () {
+  const tls = {
+    ca: [
+      readFileSync(join(__dirname, './mtls/ca.crt'), 'utf8')
+    ],
+    key: readFileSync(join(__dirname, './mtls/client.key'), 'utf8'),
+    cert: readFileSync(join(__dirname, './mtls/client.crt'), 'utf8'),
+    rejectUnauthorized: false,
+    servername: 'localhost'
+  }
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: tls
+  })
+
+  client.request({
+    path: '/',
+    method: 'GET'
+  }).then((res) => {
+    console.log(res.statusCode)
+    process.exitCode = res.statusCode === 200 ? 0 : 1
+    return res.body.json()
+  }).then((json) => {
+    console.log(json)
+    client.destroy()
+  })
+    .then(() => server.close())
+})

--- a/test/acceptance/setup-mtls.sh
+++ b/test/acceptance/setup-mtls.sh
@@ -1,0 +1,90 @@
+# Description: Setup mutual TLS for acceptance tests
+
+set -e
+
+# setup variables
+TEST_ASSET_TTL=7 # one week, but probably regenerated each test
+COMMON_NAME="${1:-localhost}"
+echo "Using common name: ${COMMON_NAME}"
+echo "This can be changed by passing a command line argument to the script:"
+echo "  $0 my-common-name"
+echo
+
+# switch to acceptance test root directory
+cd $(dirname $0)
+
+# create clean mtls directory
+rm -rf mtls
+mkdir mtls
+
+# wrapper function to run openssl command and handle result
+run_openssl() {
+    set +e
+    
+    local cmd="$*"    
+    local operation=$2
+    case "${operation}" in
+        "genpkey") operation="generate private key" ;;
+        "req")     operation="generate certificate signing request" ;;
+        "x509")    operation="sign certificate" ;;
+    esac
+
+    ${cmd} &> /dev/null
+    if [ $? -eq 0 ]; then
+        local asset=$(echo "$*" | awk '{
+            for (i=1; i<NF; i++) 
+                if ($i == "-out") print $(i+1)
+        }')
+        echo -e "  \e[32m✔\e[0m ${operation}: \e[34m${asset}\e[0m"
+    else
+        echo -e "  \e[31m✖\e[0m could not ${operation}:\n ${cmd}" >&2
+        exit 1
+    fi
+}
+
+echo "Setting up mutual TLS assets..."
+
+# setup CA assets
+run_openssl openssl genpkey \
+    -algorithm RSA \
+    -out ./mtls/ca.key \
+    -aes-256-cbc \
+    -pkeyopt rsa_keygen_bits:2048 \
+    -pass pass:ca-password
+run_openssl openssl req -new \
+    -key ./mtls/ca.key -passin pass:ca-password \
+    -out ./mtls/ca.csr -subj "/CN=fcp-dal-acceptance-test-ca"
+run_openssl openssl x509 -req \
+    -signkey ./mtls/ca.key -passin pass:ca-password \
+    -in ./mtls/ca.csr -out ./mtls/ca.crt \
+    -days ${TEST_ASSET_TTL}
+
+# setup server assets
+run_openssl openssl genpkey \
+    -algorithm RSA \
+    -out ./mtls/server.key \
+    -pkeyopt rsa_keygen_bits:2048 \
+    -pass pass:server-password
+run_openssl openssl req -new \
+    -key ./mtls/server.key -passin pass:server-password \
+    -out ./mtls/server.csr -subj "/CN=${COMMON_NAME}"
+run_openssl openssl x509 -req \
+    -in ./mtls/server.csr -out ./mtls/server.crt \
+    -CA ./mtls/ca.crt -CAkey ./mtls/ca.key -passin pass:ca-password \
+    -days ${TEST_ASSET_TTL}
+
+# setup client assets
+run_openssl openssl genpkey \
+    -algorithm RSA \
+    -out ./mtls/client.key \
+    -pkeyopt rsa_keygen_bits:2048 \
+    -pass pass:client-password
+run_openssl openssl req -new \
+    -key ./mtls/client.key -passin pass:client-password \
+    -out ./mtls/client.csr -subj "/CN=${COMMON_NAME}"
+run_openssl openssl x509 -req \
+    -in ./mtls/client.csr -out ./mtls/client.crt \
+    -CA ./mtls/ca.crt -CAkey ./mtls/ca.key -passin pass:ca-password \
+    -days ${TEST_ASSET_TTL}
+
+echo "MTLS setup complete"


### PR DESCRIPTION
- [x] create local testing SSL assets using the convenience script:
   ```shell
    test/acceptance/setup-mtls.sh
    ```
    > Using common name: localhost
    This can be changed by passing a command line argument to the script:
        test/acceptance/setup-mtls.sh my-common-name
    >
    > Setting up mutual TLS assets...
        ✔ generate private key: ./mtls/ca.key
        ✔ generate certificate signing request: ./mtls/ca.csr
        ✔ sign certificate: ./mtls/ca.crt
        ✔ generate private key: ./mtls/server.key
        ✔ generate certificate signing request: ./mtls/server.csr
        ✔ sign certificate: ./mtls/server.crt
        ✔ generate private key: ./mtls/client.key
        ✔ generate certificate signing request: ./mtls/client.csr
        ✔ sign certificate: ./mtls/client.crt
    MTLS setup complete

- [x] start a simple Node server and make an mTLS request (using the generated assets)
    ```shell
    node test/acceptance/api.ruraldev-mock.js
    ```
    > handling request...
    valid
    200
    { status: 'ok' }

- [ ] adapt the simple server example into a basic KITS mock sufficient for the API's `/get-business` route
- [ ] write an acceptance test to call the `/get-business` route
- [ ] extend the docker `compose.yml` to add in the KITS mock as a service
- [ ] run the acceptance test against the docker composed services to verify correct mTLS compatibility