### PR TITLE
fix: make /health route conform to CDP standard

### DIFF
--- a/app/routes/health.js
+++ b/app/routes/health.js
@@ -1,0 +1,7 @@
+export const healthRoute = {
+  method: 'GET',
+  path: '/health',
+  handler: (_request, h) => {
+    return h.response('ok').code(200)
+  }
+}

--- a/app/routes/healthz.js
+++ b/app/routes/healthz.js
@@ -1,7 +1,0 @@
-export const healthzRoute = {
-  method: 'GET',
-  path: '/healthz',
-  handler: (request, h) => {
-    return h.response('ok').code(200)
-  }
-}

--- a/app/server.js
+++ b/app/server.js
@@ -5,7 +5,7 @@ import { setupAppInsights } from './insights.js'
 import { DAL_APPLICATION_REQUEST_001, DAL_APPLICATION_RESPONSE_001 } from './logger/codes.js'
 import { logger } from './logger/logger.js'
 import { healthyRoute } from './routes/healthy.js'
-import { healthzRoute } from './routes/healthz.js'
+import { healthRoute } from './routes/health.js'
 
 setupAppInsights()
 
@@ -13,7 +13,7 @@ export const server = hapi.server({
   port: process.env.PORT
 })
 
-const routes = [].concat(healthyRoute, healthzRoute)
+const routes = [].concat(healthyRoute, healthRoute)
 
 server.route(routes)
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,4 +18,4 @@ sonar.tests=test/
 sonar.test.inclusions=test/**/*.test.js
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.javascript.exclusions=**/jest.config.js,**/__mocks__/**,**/node_modules/**,**/test/**,jest.init.js,app/index.js,app/insights.js,app/data-sources/rural-payments-portal/RuralPaymentsSession.js,app/graphql/server.js,app/graphql/schema.js,app/logger/**,app/routes/healthz.js,app/routes/healthy.js
+sonar.javascript.exclusions=**/jest.config.js,**/__mocks__/**,**/node_modules/**,**/test/**,jest.init.js,app/index.js,app/insights.js,app/data-sources/rural-payments-portal/RuralPaymentsSession.js,app/graphql/server.js,app/graphql/schema.js,app/logger/**,app/routes/health.js,app/routes/healthy.js

--- a/test/unit/integration/narrow/routes/health.test.js
+++ b/test/unit/integration/narrow/routes/health.test.js
@@ -5,10 +5,10 @@ describe('Healthz test', () => {
     await server.start()
   })
 
-  it('GET /healthz route returns 200', async () => {
+  it('GET /health route returns 200', async () => {
     const options = {
       method: 'GET',
-      url: '/healthz'
+      url: '/health'
     }
 
     const response = await server.inject(options)


### PR DESCRIPTION
The CDP health-check endpoint is called `/health` not `/healthz` (this is needed for the app to start-up correctly).