### PR TITLE
chore: create a local backdoor into CDP proxy

### DIFF
--- a/cdp-backdoor.yaml
+++ b/cdp-backdoor.yaml
@@ -1,0 +1,15 @@
+#
+services:
+  forwarder:
+    image: saucelabs/forwarder
+    environment:
+      - FORWARDER_PROXY=${CDP_HTTPS_PROXY}
+    command:
+      [
+        'run',
+        '--log-http=proxy:headers,url,body,errors',
+        '--log-level=debug',
+        '--proxy-localhost=direct'
+      ]
+    ports:
+      - 3128:3128


### PR DESCRIPTION
## Create a local proxy to the CDP outbound squid proxy for local testing

 1. using the [CDP Terminal](https://portal.cdp-int.defra.cloud/services/fcp-dal-api/terminal) (in the CDP portal), get the `CDP_HTTPS_PROXY` value (from the secrets):
    ```bash
    aws secretsmanager get-secret-value --secret-id "cdp/services/$SERVICE" --query SecretString --output text | jq
    ```
 3. export it locally:
    ```bash
    export CDP_HTTPS_PROXY=...
    ```
 4. start the backdoor container:
    ```bash
    docker compose -f cdp-backdoor.yaml up
    ```