### PR TITLE
test: local mTLS connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 .cache
 # cspell:disable-next-line 
 .eslintcache
+test/acceptance/mtls

--- a/compose.yml
+++ b/compose.yml
@@ -1,10 +1,32 @@
 services:
+  forwarder:
+    image: saucelabs/forwarder
+    environment:
+      - FORWARDER_PROXY=${CDP_HTTPS_PROXY}
+    command:
+      [
+        'run',
+        '--log-http=proxy:headers,url,body,errors',
+        '--log-level=debug',
+        '--proxy-localhost=direct'
+      ]
+    ports:
+      - 3128:3128
+    networks:
+      - cdp-tenant
+
   fcp-dal-api:
     build:
       context: .
     ports:
       - '3001:3001'
     environment:
+      KITS_HOST: chs-upgrade-api.ruraldev.org.uk
+      KITS_PORT: 8444
+      KITS_PATH: /extapi
+      KITS_CONNECTION_KEY: ${KITS_CONNECTION_KEY}
+      KITS_CONNECTION_CERT: ${KITS_CONNECTION_CERT}
+      HTTP_PROXY: http://forwarder:3128
       PORT: 3001
       NODE_ENV: development # overridden for friendlier logging
     networks:

--- a/src/common/helpers/fetcher.js
+++ b/src/common/helpers/fetcher.js
@@ -13,12 +13,8 @@ const fetch = (path, method = 'GET') => {
 
 export default {
   decodeBase64,
-  get fetch () {
+  get fetch() {
     if (!client) {
-      const kitsURL = new URL(config.get('kitsConnection.path'), `https://${config.get('kitsConnection.host')}`)
-      kitsURL.port = config.get('kitsConnection.port')
-      logger.info(`Creating new client for ${kitsURL.href}`)
-
       if (config.get('kitsConnection.key') && config.get('kitsConnection.cert')) {
         const tls = {
           key: decodeBase64(config.get('kitsConnection.key')),
@@ -28,9 +24,9 @@ export default {
         }
         logger.info('KITS TLS configuration:')
         logger.info(tls)
-        client = new Client(kitsURL.href, { connect: tls })
+        client = new Client(config.get('httpProxy'), { connect: tls })
       } else {
-        client = new Client(kitsURL.href)
+        client = new Client()
       }
     }
 

--- a/src/routes/get-business.js
+++ b/src/routes/get-business.js
@@ -1,18 +1,27 @@
+import { config } from '../config.js'
 import fetcher from '../common/helpers/fetcher.js'
 import { createLogger } from '../common/helpers/logging/logger.js'
 
 const logger = createLogger()
+const kitsURL = new URL(
+  config.get('kitsConnection.path'),
+  `https://${config.get('kitsConnection.host')}`
+)
+kitsURL.port = config.get('kitsConnection.port')
+logger.info(`Creating new client for ${kitsURL.href}`)
 
 const getBusiness = {
   method: 'GET',
   path: '/get-business/{id}',
   handler: async (request, h) => {
     logger.info(`GET /get-business with params: ${JSON.stringify(request.params)}`)
-    const result = await fetcher.fetch(`/organisation/${request.params.id}`)
+    const url = `${kitsURL.href}/organisation/${request.params.id}`
+    logger.info(`GET /get-business from KITS: ${url}`)
+
+    const result = await fetcher.fetch(url)
     const { name, sbi, orgId } = result.body
 
     logger.info(`business object with keys: ${Object.keys(result.body)}`)
-
     h.response({ name, sbi, orgId })
   }
 }

--- a/test/acceptance/api.ruraldev-mock.js
+++ b/test/acceptance/api.ruraldev-mock.js
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs'
+import { createServer } from 'node:https'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Client } from 'undici'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const serverOptions = {
+  ca: [
+    readFileSync(join(__dirname, './mtls/ca.crt'), 'utf8')
+  ],
+  key: readFileSync(join(__dirname, './mtls/server.key'), 'utf8'),
+  cert: readFileSync(join(__dirname, './mtls/server.crt'), 'utf8'),
+  requestCert: true,
+  rejectUnauthorized: false
+}
+
+const server = createServer(serverOptions, (req, res) => {
+  console.log('handling request...')
+  // true if client cert is valid
+  if (req.client.authorized === true) {
+    console.log('valid')
+  } else {
+    console.error('cert error:', req.client.authorizationError)
+    res.statusCode = 401
+  }
+  res.write(JSON.stringify({ status: req.client.authorizationError || 'ok' }), () => res.end())
+})
+
+server.listen(0, 'localhost', function () {
+  const tls = {
+    ca: [
+      readFileSync(join(__dirname, './mtls/ca.crt'), 'utf8')
+    ],
+    key: readFileSync(join(__dirname, './mtls/client.key'), 'utf8'),
+    cert: readFileSync(join(__dirname, './mtls/client.crt'), 'utf8'),
+    rejectUnauthorized: false,
+    servername: 'localhost'
+  }
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: tls
+  })
+
+  client.request({
+    path: '/',
+    method: 'GET'
+  }).then((res) => {
+    console.log(res.statusCode)
+    process.exitCode = res.statusCode === 200 ? 0 : 1
+    return res.body.json()
+  }).then((json) => {
+    console.log(json)
+    client.destroy()
+  })
+    .then(() => server.close())
+})

--- a/test/acceptance/setup-mtls.sh
+++ b/test/acceptance/setup-mtls.sh
@@ -1,0 +1,90 @@
+# Description: Setup mutual TLS for acceptance tests
+
+set -e
+
+# setup variables
+TEST_ASSET_TTL=7 # one week, but probably regenerated each test
+COMMON_NAME="${1:-localhost}"
+echo "Using common name: ${COMMON_NAME}"
+echo "This can be changed by passing a command line argument to the script:"
+echo "  $0 my-common-name"
+echo
+
+# switch to acceptance test root directory
+cd $(dirname $0)
+
+# create clean mtls directory
+rm -rf mtls
+mkdir mtls
+
+# wrapper function to run openssl command and handle result
+run_openssl() {
+    set +e
+    
+    local cmd="$*"    
+    local operation=$2
+    case "${operation}" in
+        "genpkey") operation="generate private key" ;;
+        "req")     operation="generate certificate signing request" ;;
+        "x509")    operation="sign certificate" ;;
+    esac
+
+    ${cmd} &> /dev/null
+    if [ $? -eq 0 ]; then
+        local asset=$(echo "$*" | awk '{
+            for (i=1; i<NF; i++) 
+                if ($i == "-out") print $(i+1)
+        }')
+        echo -e "  \e[32m✔\e[0m ${operation}: \e[34m${asset}\e[0m"
+    else
+        echo -e "  \e[31m✖\e[0m could not ${operation}:\n ${cmd}" >&2
+        exit 1
+    fi
+}
+
+echo "Setting up mutual TLS assets..."
+
+# setup CA assets
+run_openssl openssl genpkey \
+    -algorithm RSA \
+    -out ./mtls/ca.key \
+    -aes-256-cbc \
+    -pkeyopt rsa_keygen_bits:2048 \
+    -pass pass:ca-password
+run_openssl openssl req -new \
+    -key ./mtls/ca.key -passin pass:ca-password \
+    -out ./mtls/ca.csr -subj "/CN=fcp-dal-acceptance-test-ca"
+run_openssl openssl x509 -req \
+    -signkey ./mtls/ca.key -passin pass:ca-password \
+    -in ./mtls/ca.csr -out ./mtls/ca.crt \
+    -days ${TEST_ASSET_TTL}
+
+# setup server assets
+run_openssl openssl genpkey \
+    -algorithm RSA \
+    -out ./mtls/server.key \
+    -pkeyopt rsa_keygen_bits:2048 \
+    -pass pass:server-password
+run_openssl openssl req -new \
+    -key ./mtls/server.key -passin pass:server-password \
+    -out ./mtls/server.csr -subj "/CN=${COMMON_NAME}"
+run_openssl openssl x509 -req \
+    -in ./mtls/server.csr -out ./mtls/server.crt \
+    -CA ./mtls/ca.crt -CAkey ./mtls/ca.key -passin pass:ca-password \
+    -days ${TEST_ASSET_TTL}
+
+# setup client assets
+run_openssl openssl genpkey \
+    -algorithm RSA \
+    -out ./mtls/client.key \
+    -pkeyopt rsa_keygen_bits:2048 \
+    -pass pass:client-password
+run_openssl openssl req -new \
+    -key ./mtls/client.key -passin pass:client-password \
+    -out ./mtls/client.csr -subj "/CN=${COMMON_NAME}"
+run_openssl openssl x509 -req \
+    -in ./mtls/client.csr -out ./mtls/client.crt \
+    -CA ./mtls/ca.crt -CAkey ./mtls/ca.key -passin pass:ca-password \
+    -days ${TEST_ASSET_TTL}
+
+echo "MTLS setup complete"


### PR DESCRIPTION
> NOTE: for documentation purposes only!

## Solution approach

This proposed mTLS solution uses the `Client` API from `undici`.
The constructed `Client` is configured to call the proxy URL, and mTLS config is set via the `connection` options.
Data can then be fetched using the client's `request` method, which takes the target URL as the `path` option.

## Result

Sadly this doesn't seem to work :cry:
Calls tracked via the handy local `forwarder` (setup as part of docker compose) show the requests do hit the local proxy :heavy_check_mark:
But requests fail to pass along the mTLS credentials :x: 
See the full logs below...

```
forwarder-1  | 2025/04/01 16:30:38.822306 [proxy] [DEBUG] accepted connection from 172.19.0.2:42002
forwarder-1  | 2025/04/01 16:30:38.838271 [proxy] [DEBUG] [1-04f33838] opening connection to tcp proxy.dev.cdp-int.defra.cloud:443
forwarder-1  | 2025/04/01 16:30:39.657958 [proxy] [DEBUG] [1-04f33838] connection to tcp proxy.dev.cdp-int.defra.cloud:443 established duration=819.633045ms
forwarder-1  | 2025/04/01 16:30:40.025921 [proxy] [ERROR] [1-04f33838] failed to round trip host=chs-upgrade-api.ruraldev.org.uk:8444 method=GET path=/extapi/organisation/123: remote error: tls: certificate required
forwarder-1  | 2025/04/01 16:30:40.026034 [proxy] [INFO] [1-04f33838] GET https://chs-upgrade-api.ruraldev.org.uk:8444/extapi/organisation/123 status=502 duration=1.187796254s
forwarder-1  | GET https://chs-upgrade-api.ruraldev.org.uk:8444/extapi/organisation/123 HTTP/1.1
forwarder-1  | Host: chs-upgrade-api.ruraldev.org.uk:8444
forwarder-1  | Content-Length: 0
forwarder-1  | User-Agent: 
forwarder-1  | Via: 1.1 forwarder-d3e0b19a91f6593b7502
forwarder-1  | X-Forwarded-For: 172.19.0.2
forwarder-1  | X-Forwarded-Host: chs-upgrade-api.ruraldev.org.uk:8444
forwarder-1  | X-Forwarded-Proto: https
forwarder-1  | X-Forwarded-Url: https://chs-upgrade-api.ruraldev.org.uk:8444/extapi/organisation/123
forwarder-1  | 
forwarder-1  | HTTP/1.1 502 Bad Gateway
forwarder-1  | Content-Length: 122
forwarder-1  | Content-Type: text/plain; charset=utf-8
forwarder-1  | X-Forwarder-Error: forwarder remote error: tls: certificate required
forwarder-1  | 
forwarder-1  | 
forwarder-1  | 2025/04/01 16:30:44.043835 [proxy] [DEBUG] closing connection from 172.19.0.2:42002 duration=5.221490824s
```