### PR TITLE
feat: mTLS via proxyagent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 .cache
 # cspell:disable-next-line 
 .eslintcache
+test/acceptance/mtls

--- a/compose.yml
+++ b/compose.yml
@@ -1,10 +1,32 @@
 services:
+  forwarder:
+    image: saucelabs/forwarder
+    environment:
+      - FORWARDER_PROXY=${CDP_HTTPS_PROXY}
+    command:
+      [
+        'run',
+        '--log-http=proxy:headers,url,body,errors',
+        '--log-level=debug',
+        '--proxy-localhost=direct'
+      ]
+    ports:
+      - 3128:3128
+    networks:
+      - cdp-tenant
+
   fcp-dal-api:
     build:
       context: .
     ports:
       - '3001:3001'
     environment:
+      KITS_HOST: chs-upgrade-api.ruraldev.org.uk
+      KITS_PORT: 8444
+      KITS_PATH: /extapi
+      KITS_CONNECTION_KEY: ${KITS_CONNECTION_KEY}
+      KITS_CONNECTION_CERT: ${KITS_CONNECTION_CERT}
+      HTTP_PROXY: http://forwarder:3128
       PORT: 3001
       NODE_ENV: development # overridden for friendlier logging
     networks:

--- a/src/common/helpers/proxy/setup-proxy.js
+++ b/src/common/helpers/proxy/setup-proxy.js
@@ -1,6 +1,8 @@
+import tls from 'node:tls'
 import { ProxyAgent, setGlobalDispatcher } from 'undici'
 
 import { config } from '../../../config.js'
+import fetcher from '../fetcher.js'
 import { createLogger } from '../logging/logger.js'
 
 const logger = createLogger()
@@ -9,13 +11,29 @@ const logger = createLogger()
  * If HTTP_PROXY is set setupProxy() will enable it globally
  * for undici http clients.
  */
-export function setupProxy () {
+export function setupProxy() {
   const proxyUrl = config.get('httpProxy')
 
   if (proxyUrl) {
     logger.info('setting up global proxies')
 
+    const requestTls = {
+      host: config.get('kitsConnection.host'),
+      port: config.get('kitsConnection.port'),
+      path: config.get('kitsConnection.path'),
+      // rejectUnauthorized: false,
+      servername: config.get('kitsConnection.host'),
+      secureContext: tls.createSecureContext({
+        key: fetcher.decodeBase64(config.get('kitsConnection.key')),
+        cert: fetcher.decodeBase64(config.get('kitsConnection.cert'))
+      })
+    }
+    logger.info('KITS TLS configuration:', requestTls)
+
+    const proxyAgent = new ProxyAgent({ uri: proxyUrl, requestTls })
     // Undici proxy
-    setGlobalDispatcher(new ProxyAgent(proxyUrl))
+    setGlobalDispatcher(proxyAgent)
+
+    return proxyAgent
   }
 }

--- a/src/routes/get-business.js
+++ b/src/routes/get-business.js
@@ -1,19 +1,34 @@
-import fetcher from '../common/helpers/fetcher.js'
+import { request } from 'undici'
+import { config } from '../config.js'
+// import fetcher from '../common/helpers/fetcher.js'
 import { createLogger } from '../common/helpers/logging/logger.js'
 
 const logger = createLogger()
+const kitsURL = new URL(
+  config.get('kitsConnection.path'),
+  `https://${config.get('kitsConnection.host')}`
+)
+kitsURL.port = config.get('kitsConnection.port')
+logger.info(`Creating new client for ${kitsURL.href}`)
 
 const getBusiness = {
   method: 'GET',
   path: '/get-business/{id}',
-  handler: async (request, h) => {
-    logger.info(`GET /get-business with params: ${JSON.stringify(request.params)}`)
-    const result = await fetcher.fetch(`/organisation/${request.params.id}`)
-    const { name, sbi, orgId } = result.body
+  handler: async (req, h) => {
+    logger.info(`GET /get-business with params: ${JSON.stringify(req.params)}`)
+    const { statusCode, body } = await request(`${kitsURL.href}/organisation/${req.params.id}`,{
+      headers: {
+        'content-type': 'application/json',
+        email: 'Test.User01@defra.gov.uk'
+      }
+    })
+    logger.info(`Response status code: ${statusCode}`)
 
-    logger.info(`business object with keys: ${Object.keys(result.body)}`)
+    const result = await body.json()
+    logger.info(`business object with keys: ${Object.keys(result)}`)
+    const { name, sbi, orgId } = result._data
 
-    h.response({ name, sbi, orgId })
+    return h.response({ name, sbi, orgId })
   }
 }
 

--- a/test/acceptance/api.ruraldev-mock.js
+++ b/test/acceptance/api.ruraldev-mock.js
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs'
+import { createServer } from 'node:https'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Client } from 'undici'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const serverOptions = {
+  ca: [
+    readFileSync(join(__dirname, './mtls/ca.crt'), 'utf8')
+  ],
+  key: readFileSync(join(__dirname, './mtls/server.key'), 'utf8'),
+  cert: readFileSync(join(__dirname, './mtls/server.crt'), 'utf8'),
+  requestCert: true,
+  rejectUnauthorized: false
+}
+
+const server = createServer(serverOptions, (req, res) => {
+  console.log('handling request...')
+  // true if client cert is valid
+  if (req.client.authorized === true) {
+    console.log('valid')
+  } else {
+    console.error('cert error:', req.client.authorizationError)
+    res.statusCode = 401
+  }
+  res.write(JSON.stringify({ status: req.client.authorizationError || 'ok' }), () => res.end())
+})
+
+server.listen(0, 'localhost', function () {
+  const tls = {
+    ca: [
+      readFileSync(join(__dirname, './mtls/ca.crt'), 'utf8')
+    ],
+    key: readFileSync(join(__dirname, './mtls/client.key'), 'utf8'),
+    cert: readFileSync(join(__dirname, './mtls/client.crt'), 'utf8'),
+    rejectUnauthorized: false,
+    servername: 'localhost'
+  }
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: tls
+  })
+
+  client.request({
+    path: '/',
+    method: 'GET'
+  }).then((res) => {
+    console.log(res.statusCode)
+    process.exitCode = res.statusCode === 200 ? 0 : 1
+    return res.body.json()
+  }).then((json) => {
+    console.log(json)
+    client.destroy()
+  })
+    .then(() => server.close())
+})

--- a/test/acceptance/setup-mtls.sh
+++ b/test/acceptance/setup-mtls.sh
@@ -1,0 +1,90 @@
+# Description: Setup mutual TLS for acceptance tests
+
+set -e
+
+# setup variables
+TEST_ASSET_TTL=7 # one week, but probably regenerated each test
+COMMON_NAME="${1:-localhost}"
+echo "Using common name: ${COMMON_NAME}"
+echo "This can be changed by passing a command line argument to the script:"
+echo "  $0 my-common-name"
+echo
+
+# switch to acceptance test root directory
+cd $(dirname $0)
+
+# create clean mtls directory
+rm -rf mtls
+mkdir mtls
+
+# wrapper function to run openssl command and handle result
+run_openssl() {
+    set +e
+    
+    local cmd="$*"    
+    local operation=$2
+    case "${operation}" in
+        "genpkey") operation="generate private key" ;;
+        "req")     operation="generate certificate signing request" ;;
+        "x509")    operation="sign certificate" ;;
+    esac
+
+    ${cmd} &> /dev/null
+    if [ $? -eq 0 ]; then
+        local asset=$(echo "$*" | awk '{
+            for (i=1; i<NF; i++) 
+                if ($i == "-out") print $(i+1)
+        }')
+        echo -e "  \e[32m✔\e[0m ${operation}: \e[34m${asset}\e[0m"
+    else
+        echo -e "  \e[31m✖\e[0m could not ${operation}:\n ${cmd}" >&2
+        exit 1
+    fi
+}
+
+echo "Setting up mutual TLS assets..."
+
+# setup CA assets
+run_openssl openssl genpkey \
+    -algorithm RSA \
+    -out ./mtls/ca.key \
+    -aes-256-cbc \
+    -pkeyopt rsa_keygen_bits:2048 \
+    -pass pass:ca-password
+run_openssl openssl req -new \
+    -key ./mtls/ca.key -passin pass:ca-password \
+    -out ./mtls/ca.csr -subj "/CN=fcp-dal-acceptance-test-ca"
+run_openssl openssl x509 -req \
+    -signkey ./mtls/ca.key -passin pass:ca-password \
+    -in ./mtls/ca.csr -out ./mtls/ca.crt \
+    -days ${TEST_ASSET_TTL}
+
+# setup server assets
+run_openssl openssl genpkey \
+    -algorithm RSA \
+    -out ./mtls/server.key \
+    -pkeyopt rsa_keygen_bits:2048 \
+    -pass pass:server-password
+run_openssl openssl req -new \
+    -key ./mtls/server.key -passin pass:server-password \
+    -out ./mtls/server.csr -subj "/CN=${COMMON_NAME}"
+run_openssl openssl x509 -req \
+    -in ./mtls/server.csr -out ./mtls/server.crt \
+    -CA ./mtls/ca.crt -CAkey ./mtls/ca.key -passin pass:ca-password \
+    -days ${TEST_ASSET_TTL}
+
+# setup client assets
+run_openssl openssl genpkey \
+    -algorithm RSA \
+    -out ./mtls/client.key \
+    -pkeyopt rsa_keygen_bits:2048 \
+    -pass pass:client-password
+run_openssl openssl req -new \
+    -key ./mtls/client.key -passin pass:client-password \
+    -out ./mtls/client.csr -subj "/CN=${COMMON_NAME}"
+run_openssl openssl x509 -req \
+    -in ./mtls/client.csr -out ./mtls/client.crt \
+    -CA ./mtls/ca.crt -CAkey ./mtls/ca.key -passin pass:ca-password \
+    -days ${TEST_ASSET_TTL}
+
+echo "MTLS setup complete"


### PR DESCRIPTION
## Fetch data from KITS

This code achieves a working fetch from KITS via a local proxy and supplying the necessary mTLS assets for the KITS connection.

 1. set the necessary env vars from the associated env's secrets:
    ```bash
    export CDP_HTTPS_PROXY=...
    export KITS_CONNECTION_KEY=...
    export KITS_CONNECTION_CERT=...
    ```
 2. run the docker compose setup:
    ```bash
    docker compose up -d --build
    docker compose logs -f fcp-dal-api
    ```
 3. make a request to the data fetch endpoint:
    ```bash
    curl http://localhost:3001/get-business/5613879 ; echo
    ```