### PR TITLE
Add graphql explorer view

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -35,3 +35,5 @@ EVENT_HUB_DISABLED=true
 EVENT_HUB_CONNECTION_STRING='Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=AppMonitoring;SharedAccessKey=fakekey=;EntityPath=fake-event-hub-name'
 EVENT_HUB_NAME='fake-event-hub-name'
 SOC_APPPLICATION_IDENTIFIER='DAL001'
+
+GRAPHQL_DASHBOARD_ENABLED='true'

--- a/app/graphql/server.js
+++ b/app/graphql/server.js
@@ -5,15 +5,15 @@ import { createSchema } from './schema.js'
 
 export const schema = await createSchema()
 
+export const enableApolloLandingPage = () => {
+  if (process.env.GRAPHQL_DASHBOARD_ENABLED === 'true') {
+    return ApolloServerPluginLandingPageLocalDefault()
+  }
+
+  return ApolloServerPluginLandingPageDisabled()
+}
+
 export const apolloServer = new ApolloServer({
   schema,
-  plugins: [
-    (() => {
-      if (process.env?.NODE_ENV === 'production') {
-        return ApolloServerPluginLandingPageDisabled()
-      }
-
-      return ApolloServerPluginLandingPageLocalDefault()
-    })()
-  ]
+  plugins: [enableApolloLandingPage()]
 })

--- a/test/unit/integration/narrow/routes/graphql-dashboard.test.js
+++ b/test/unit/integration/narrow/routes/graphql-dashboard.test.js
@@ -1,0 +1,25 @@
+import { apolloServer, enableApolloLandingPage } from '../../../../../app/graphql/server.js'
+
+describe('GraphQL Dashboard test', () => {
+  it('expects graphql dashboard to be enabled when GRAPHQL_DASHBOARD_ENABLED is set in .env.test', async () => {
+    expect(apolloServer.internals.plugins.length).toBe(1)
+    expect(apolloServer.internals.plugins[0].__is_disabled_plugin__).toBeUndefined()
+  })
+
+  it('enables graphql dashboard when GRAPHQL_DASHBOARD_ENABLED is enabled', async () => {
+    process.env.GRAPHQL_DASHBOARD_ENABLED = 'true'
+
+    const response = enableApolloLandingPage()
+
+    expect(response.__is_disabled_plugin__).toBeUndefined()
+  })
+
+  it('disables graphql dashboard when GRAPHQL_DASHBOARD_ENABLED is disabled', async () => {
+    process.env.GRAPHQL_DASHBOARD_ENABLED = 'false'
+
+    const response = enableApolloLandingPage()
+
+    expect(response.__is_disabled_plugin__).toBeDefined()
+    expect(response.__is_disabled_plugin__).toBe(true)
+  })
+})


### PR DESCRIPTION
When env var GRAPHQL_DASHBOARD_ENABLED is available and set to "true" show the graphql explorer when navigating to /graphql