### PR TITLE
ci: fix TL;DR docs advice

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -30,6 +30,9 @@ jobs:
           npm audit --omit=dev
           npm ci
 
+      - name: Lint code
+        run: npm run lint
+
       - name: Jest Coverage Comment
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           NODE_OPTIONS: --experimental-vm-modules
         run: |
-          docker compose up --quiet-pull -d
+          docker compose up --quiet-pull --build -d
           set +e
           npm i graphql-request
           curl -s --max-time 10 --retry 5 --retry-delay 1 --retry-all-errors http://localhost:3000/health

--- a/compose.yml
+++ b/compose.yml
@@ -12,6 +12,7 @@ services:
       - cdp-tenant
 
   fcp-dal-api:
+    image: defradigital/fcp-dal-api
     build:
       context: .
     ports:

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "lint": "eslint . && prettier --check .",
     "lint:fix": "eslint . --fix && prettier --log-level warn --write .",
+    "lint:test": "npm run lint && npm t",
     "prepare": "[ -d '.git' ] && husky || echo 'skipping husky'",
-    "pretest": "npm run lint",
     "dev": "nodemon --ext js,gql --watch app/ -x 'node -r dotenv/config app/index.js | jq .'",
     "start": "node -r dotenv/config app/index.js | jq .",
     "start:debug": "nodemon --inspect-brk=0.0.0.0 --ext js,gql --watch app/ app/index.js",


### PR DESCRIPTION
The headline advice for consumers was broken by recent changes, this should restore support for the following:

> ## Consumers' TL;DR
>
> This README was created for project contributors, as a consumer of the DAL API, you probably only care about the following quick start steps:
>
> ```bash
> curl https://raw.githubusercontent.com/DEFRA/fcp-dal-api/refs/heads/main/compose.yml -o dal-api-compose.yml
> docker compose -f dal-api-compose.yml up
> ```
>
> The graphQL explorer should now be available, head to http://localhost:3000/graphql in your browser, and have a play!