### PR TITLE
add pointInTime param

### DIFF
--- a/app/data-sources/rural-payments/RuralPaymentsBusiness.js
+++ b/app/data-sources/rural-payments/RuralPaymentsBusiness.js
@@ -109,7 +109,22 @@ export class RuralPaymentsBusiness extends RuralPayments {
   }
 
   async getCountyParishHoldingsBySBI(sbi) {
-    const response = await this.get(`SitiAgriApi/cv/cphByBusiness/sbi/${sbi}/list`)
+    const response = await this.get(`SitiAgriApi/cv/cphByBusiness/sbi/${sbi}/list`, {
+      params: {
+        // pointInTime: current date/time formatted as `YYYY-MM-DD hh:mm`
+        pointInTime: new Date()
+          .toLocaleString('en-GB', {
+            timeZone: 'Europe/London',
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false
+          })
+          .replace(/(\d{2})\/(\d{2})\/(\d{4}), (\d{2}:\d{2})/, '$3-$2-$1 $4')
+      }
+    })
     return response.data
   }
 

--- a/test/graphql/business.test.js
+++ b/test/graphql/business.test.js
@@ -119,23 +119,25 @@ const setupNock = () => {
     { name: 'Permanent Crops', area: 1 }
   ])
 
-  v1.get('/SitiAgriApi/cv/cphByBusiness/sbi/sbi/list').reply(200, {
-    data: [
-      {
-        sbi: 'mockSbi',
-        dt_insert: 'mockDtInsert1',
-        dt_delete: 'mockDtDelete1',
-        cph_number: 'mockCph1',
-        parish: 'mockParish',
-        species: 'mockSpecies',
-        start_date: '2020-03-20T00:00:00:000+0100',
-        end_date: '2021-03-20T00:00:00:000+0100',
-        address: 'mockAddress',
-        x: 123456,
-        y: 654321
-      }
-    ]
-  })
+  v1.get('/SitiAgriApi/cv/cphByBusiness/sbi/sbi/list')
+    .query(({ pointInTime }) => /\d{4}-\d{2}-\d{2} \d{2}:\d{2}/.test(pointInTime))
+    .reply(200, {
+      data: [
+        {
+          sbi: 'mockSbi',
+          dt_insert: 'mockDtInsert1',
+          dt_delete: 'mockDtDelete1',
+          cph_number: 'mockCph1',
+          parish: 'mockParish',
+          species: 'mockSpecies',
+          start_date: '2020-03-20T00:00:00:000+0100',
+          end_date: '2021-03-20T00:00:00:000+0100',
+          address: 'mockAddress',
+          x: 123456,
+          y: 654321
+        }
+      ]
+    })
 }
 
 describe('Query.business', () => {

--- a/test/unit/data-sources/rural-payments-business.test.js
+++ b/test/unit/data-sources/rural-payments-business.test.js
@@ -157,13 +157,26 @@ describe('Rural Payments Business', () => {
   })
 
   describe('getCountyParishHoldingsBySBI', () => {
+    beforeAll(() => {
+      jest.useFakeTimers()
+    })
+
+    afterAll(() => {
+      jest.useRealTimers()
+    })
+
     test('should return county parish holdings list', async () => {
+      jest.setSystemTime(new Date('2025-01-01T13:35'))
+
       const mockResponse = { data: 'mockData' }
       httpGet.mockImplementationOnce(async () => mockResponse)
 
       const result = await ruralPaymentsBusiness.getCountyParishHoldingsBySBI('mockSbi')
       expect(result).toEqual(mockResponse.data)
-      expect(httpGet).toHaveBeenCalledWith('SitiAgriApi/cv/cphByBusiness/sbi/mockSbi/list')
+
+      expect(httpGet).toHaveBeenCalledWith('SitiAgriApi/cv/cphByBusiness/sbi/mockSbi/list', {
+        params: { pointInTime: '2025-01-01 13:35' }
+      })
     })
   })
 


### PR DESCRIPTION
For each call to the cph endpoint we need to send a `pointInTime` parameter with the current date/time in a random, non-url safe format `YYYY-DD-MM hh:mm` 🤦‍♂️ 