### PR TITLE
feat: add customer data

### DIFF
--- a/app/graphql/types/business/agreement.gql
+++ b/app/graphql/types/business/agreement.gql
@@ -85,7 +85,7 @@ type PaymentSchedule {
   """
   Action area - Area (in hectares) of the action.
   """
-  actionArea: Int @on
+  actionArea: Float @on
 
   """
   Action MTL - Length (in metres) of the action.
@@ -100,7 +100,7 @@ type PaymentSchedule {
   """
   Parcel total area - Total area (in hectares) of the parcel.
   """
-  parcelTotalArea: Int @on
+  parcelTotalArea: Float @on
 
   """
   Payment schedule start date for the payment schedule.

--- a/app/graphql/types/common.gql
+++ b/app/graphql/types/common.gql
@@ -124,17 +124,17 @@ type EntityStatus {
   """
   Indicates whether the customer or business account is locked.
   """
-  locked: Boolean
+  locked: Boolean @on
 
   """
   Indicates whether the customer or business account has been confirmed.
   """
-  confirmed: Boolean
+  confirmed: Boolean @on
 
   """
   Indicates whether the customer or business account has been deactivated.
   """
-  deactivated: Boolean
+  deactivated: Boolean @on
 }
 
 "Represents data about a pagination details for a list of items"

--- a/app/graphql/types/customer/customer.gql
+++ b/app/graphql/types/customer/customer.gql
@@ -15,27 +15,32 @@ type CustomerInfo {
   """
   Telephone number of the customer.
   """
-  phone: Phone
+  phone: Phone @on
 
   """
   Email address of the customer.
   """
-  email: Email
+  email: Email @on
 
   """
   Status of the customer record/account.
   """
-  status: EntityStatus
+  status: EntityStatus @on
 
   """
   Address of the customer.
   """
-  address: Address
+  address: Address @on
 
   """
   Do not contact status of the customer email address.
   """
   doNotContact: Boolean @on
+
+  """
+  Other IDs for this customer.
+  """
+  personalIdentifiers: [String] @on
 }
 
 """

--- a/app/logger/winstonFormatters.js
+++ b/app/logger/winstonFormatters.js
@@ -46,11 +46,12 @@ const buildEvent = (kind, category, type, created, duration, outcome, reference)
   }
 
 const buildUrl = ({ body, path }) =>
-  body &&
-  path && {
+  (body || path) && {
     url: {
       full: path,
-      ...(body && { query: new URLSearchParams(body).toString() })
+      ...(body && {
+        query: new URLSearchParams(typeof body === 'string' ? JSON.parse(body) : body).toString()
+      })
     }
   }
 

--- a/app/transformers/rural-payments/customer.js
+++ b/app/transformers/rural-payments/customer.js
@@ -71,6 +71,7 @@ export const ruralPaymentsPortalCustomerTransformer = (data) => {
       validated: data.emailValidated
     },
     doNotContact: data.doNotContact,
+    personalIdentifiers: data.personalIdentifiers,
     address: kitsAddressToDalAddress(data.address),
     status: transformEntityStatus(data)
   }

--- a/app/utils/numbers.js
+++ b/app/utils/numbers.js
@@ -1,3 +1,3 @@
 const squareMetersToHectares = 0.0001
 export const convertSquareMetersToHectares = (area) =>
-  parseFloat((parseFloat(area) * squareMetersToHectares).toFixed(4))
+  parseFloat((parseFloat(area) * squareMetersToHectares).toFixed(4)) || 0

--- a/test/acceptance/local-dev-check.test.js
+++ b/test/acceptance/local-dev-check.test.js
@@ -67,7 +67,7 @@ const business = {
     hasLandInWales: false,
     hasAdditionalBusinessActivities: false,
     additionalBusinessActivities: [],
-    isAccountablePeopleDeclarationComplete: null,
+    isAccountablePeopleDeclarationCompleted: false,
     dateStartedFarming: null,
     landConfirmed: true,
     status: {
@@ -550,7 +550,7 @@ describe('Local mocked dev check', () => {
               code
               type
             }
-            isAccountablePeopleDeclarationComplete
+            isAccountablePeopleDeclarationCompleted
             dateStartedFarming
             landConfirmed
             status {

--- a/test/acceptance/local-dev-check.test.js
+++ b/test/acceptance/local-dev-check.test.js
@@ -278,10 +278,10 @@ const paymentSchedules = [
     year: 2017,
     sheetName: 'NY8366',
     parcelName: '2327',
-    actionArea: 17166,
+    actionArea: 1.7166,
     actionMTL: null,
     actionUnits: null,
-    parcelTotalArea: 17166,
+    parcelTotalArea: 1.7166,
     startDate: '2017-01-01T00:00:00.000Z',
     endDate: '2017-12-31T00:00:00.000Z'
   }

--- a/test/acceptance/local-dev-check.test.js
+++ b/test/acceptance/local-dev-check.test.js
@@ -1,60 +1,746 @@
 import { GraphQLClient, gql } from 'graphql-request'
 
-const query = gql`
-  query Business($sbi: ID!, $crn: ID!) {
-    business(sbi: $sbi) {
-      organisationId
-      sbi
-      info {
-        name
-        reference
-        vat
-        traderNumber
-        vendorNumber
+const business = {
+  organisationId: '5565448',
+  sbi: '107183280',
+  info: {
+    name: 'HENLEY, RE',
+    reference: '1102179604',
+    vat: 'GB123456789',
+    traderNumber: '010203040506070880980',
+    vendorNumber: '694523',
+    address: {
+      pafOrganisationName: 'FORTESCUE ESTATES',
+      line1: '76 Robinswood Road',
+      line2: 'UPPER CHUTE',
+      line3: 'Child Okeford',
+      line4: null,
+      line5: null,
+      buildingNumberRange: '7',
+      buildingName: 'STOCKWELL HALL',
+      flatName: 'THE COACH HOUSE',
+      street: 'HAREWOOD AVENUE',
+      city: 'DARLINGTON',
+      county: 'Dorset',
+      postalCode: 'CO9 3LS',
+      country: 'United Kingdom',
+      uprn: '10008695234',
+      dependentLocality: 'ELLICOMBE',
+      doubleDependentLocality: 'WOODTHORPE',
+      typeId: null
+    },
+    correspondenceAddress: null,
+    isCorrespondenceAsBusinessAddress: false,
+    email: {
+      address: 'henleyrej@eryelnehk.com.test',
+      validated: true
+    },
+    correspondenceEmail: {
+      address: null,
+      validated: false
+    },
+    phone: {
+      mobile: null,
+      landline: '01234031859'
+    },
+    correspondencePhone: {
+      mobile: null,
+      landline: null
+    },
+    legalStatus: {
+      code: 102111,
+      type: 'Sole Proprietorship'
+    },
+    type: {
+      code: 101443,
+      type: 'Not Specified'
+    },
+    registrationNumbers: {
+      companiesHouse: null,
+      charityCommission: null
+    },
+    additionalSbis: ['105179439'],
+    lastUpdated: '2023-07-18T15:38:20.448Z',
+    isFinancialToBusinessAddress: false,
+    hasLandInNorthernIreland: false,
+    hasLandInScotland: false,
+    hasLandInWales: false,
+    hasAdditionalBusinessActivities: false,
+    additionalBusinessActivities: [],
+    isAccountablePeopleDeclarationComplete: null,
+    dateStartedFarming: null,
+    landConfirmed: true,
+    status: {
+      locked: false,
+      confirmed: true,
+      deactivated: false
+    }
+  },
+  customers: [
+    {
+      personId: '5007136',
+      firstName: 'David',
+      lastName: 'Paul',
+      crn: '0866159801',
+      role: 'Employee'
+    },
+    {
+      personId: '5263421',
+      firstName: 'Nicholas',
+      lastName: 'SANGSTER',
+      crn: '1638563942',
+      role: 'Business Partner'
+    },
+    {
+      personId: '5302028',
+      firstName:
+        'Ingrid Jerimire Klaufichus Limouhetta Mortimious Neuekind Orpheus Perimillian Quixillotrio Reviticlese',
+      lastName: 'Cook',
+      crn: '9477368292',
+      role: 'Agent'
+    },
+    {
+      personId: '5311964',
+      firstName: 'Trevor',
+      lastName: 'Graham',
+      crn: '2446747270',
+      role: 'Agent'
+    },
+    {
+      personId: '5331098',
+      firstName: 'Marcus',
+      lastName: 'Twigden',
+      crn: '4804081228',
+      role: 'Agent'
+    },
+    {
+      personId: '5778203',
+      firstName: 'Oliver',
+      lastName: 'Colwill',
+      crn: '6148241575',
+      role: 'Agent'
+    }
+  ],
+  customer: {
+    personId: '5302028',
+    firstName:
+      'Ingrid Jerimire Klaufichus Limouhetta Mortimious Neuekind Orpheus Perimillian Quixillotrio Reviticlese',
+    lastName: 'Cook',
+    crn: '9477368292',
+    role: 'Agent',
+    permissionGroups: [
+      {
+        id: 'BASIC_PAYMENT_SCHEME',
+        level: 'SUBMIT',
+        functions: [
+          'View business summary',
+          'View claims',
+          'View land, features and covers',
+          'Create and edit a claim',
+          'Amend a previously submitted claim',
+          'Amend land, features and covers',
+          'Submit a claim',
+          'Withdraw a claim',
+          'Receive warnings and notifications'
+        ]
+      },
+      {
+        id: 'BUSINESS_DETAILS',
+        level: 'FULL_PERMISSION',
+        functions: [
+          'View business details',
+          'View people associated with the business',
+          'Amend business and correspondence contact details',
+          'Amend controlled information, such as business name',
+          'Confirm business details',
+          'Amend bank account details',
+          'Make young/new farmer declaration',
+          'Add someone to the business',
+          'Give permissions on business'
+        ]
+      },
+      {
+        id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS',
+        level: 'SUBMIT',
+        functions: [
+          'View CS Agreements',
+          'View Land, Features and Cover',
+          'View CS Agreement amendments',
+          'View CS agreement Transfers',
+          'View CS Claims',
+          'Amend land, Features and Covers',
+          'Create and edit a CS claim',
+          'Amend a previously submitted claim',
+          'Create and edit a CS agreement Amendment',
+          'Revise a previously submitted agreement amendment',
+          'Create and Edit a CS agreement transfer',
+          'Revise a previously submitted agreement transfer',
+          'Submit Acceptance of CS Agreement offer',
+          'Submit rejection of CS agreement offer',
+          'Submit (and resubmit) a CS claim',
+          'Withdraw a CS claim',
+          'Submit (and resubmit) a CS agreement amendment',
+          'Withdraw a CS agreement amendment',
+          'Submit (and resubmit) a CS agreement transfer',
+          'Withdraw a CS agreement transfer',
+          'Receive warnings and notifications'
+        ]
+      },
+      {
+        id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS',
+        level: 'SUBMIT',
+        functions: [
+          'View CS Scheme eligibility',
+          'View Applications',
+          'View land, features and covers',
+          'View CS agreement offer',
+          'View draft CS Agreements',
+          'Create and edit a CS application',
+          'Amend a previously submitted CS application',
+          'Amend Land, Features and Covers',
+          'Submit CS Application',
+          'Withdraw CS application',
+          'Receive warnings and notifications'
+        ]
+      },
+      {
+        id: 'ENTITLEMENTS',
+        level: 'AMEND',
+        functions: ['View entitlements', 'Transfer entitlements', 'Apply for new entitlements']
+      },
+      {
+        id: 'LAND_DETAILS',
+        level: 'AMEND',
+        functions: [
+          'View land, features and covers',
+          'Amend land, features and covers',
+          'Transfer land'
+        ]
       }
-      customer(crn: $crn) {
-        personId
-        firstName
-        lastName
-        crn
-        role
-        permissionGroups {
-          id
-          level
-          functions
+    ]
+  },
+  land: {
+    summary: {
+      arableLandArea: 228.2947,
+      permanentCropsArea: 7.3368,
+      permanentGrasslandArea: 530.1988,
+      totalArea: 821.1645,
+      totalParcels: 302
+    },
+    parcelCovers: [
+      {
+        id: '130',
+        name: 'Permanent Grassland',
+        area: 0.4829,
+        code: '130',
+        isBpsEligible: false
+      }
+    ]
+  },
+  countyParishHoldings: [
+    {
+      cphNumber: '20/060/0001',
+      parish: 'WESTHAVEN',
+      startDate: '2020-03-20',
+      endDate: '2021-03-20',
+      species: 'CATTLE,MORE THAN FIFTY POULTRY',
+      xCoordinate: 572505,
+      yCoordinate: 152485,
+      address: 'Manor Farm, High Street, Westhaven, Devon, EX12 3AB'
+    },
+    {
+      cphNumber: '20/060/0002',
+      parish: null,
+      startDate: null,
+      endDate: null,
+      species: null,
+      xCoordinate: null,
+      yCoordinate: null,
+      address: null
+    }
+  ]
+}
+const agreement = {
+  contractId: '120809',
+  name: 'CS AGREEMENT',
+  status: 'SIGNED',
+  contractType: 'Countryside Stewardship (MT)',
+  schemeYear: 2016,
+  startDate: '2017-01-01T00:00:00.000Z',
+  endDate: '2026-12-31T00:00:00.000Z'
+}
+const paymentSchedules = [
+  {
+    optionCode: 'SW2',
+    optionDescription: 'SW2 - 4-6m buffer strip on intensive grassland',
+    commitmentGroupStartDate: '2017-01-01T00:00:00.000Z',
+    commitmentGroupEndDate: '2026-12-31T00:00:00.000Z',
+    year: 2017,
+    sheetName: 'NY8366',
+    parcelName: '2327',
+    actionArea: 17166,
+    actionMTL: null,
+    actionUnits: null,
+    parcelTotalArea: 17166,
+    startDate: '2017-01-01T00:00:00.000Z',
+    endDate: '2017-12-31T00:00:00.000Z'
+  }
+]
+const customer = {
+  personId: '5007136',
+  crn: '0866159801',
+  info: {
+    name: {
+      title: 'Dr.',
+      otherTitle: null,
+      first: 'David',
+      middle: 'Ralph',
+      last: 'Paul'
+    },
+    dateOfBirth: '1947-10-30T03:41:25.385Z',
+    phone: {
+      mobile: '1849164778',
+      landline: null
+    },
+    email: {
+      address: 'Selena_Kub@hotmail.com',
+      validated: false
+    },
+    status: {
+      locked: false,
+      confirmed: false,
+      deactivated: false
+    },
+    address: {
+      pafOrganisationName: null,
+      line1: null,
+      line2: null,
+      line3: null,
+      line4: null,
+      line5: null,
+      buildingNumberRange: null,
+      buildingName: '853',
+      flatName: null,
+      street: 'Zulauf Orchard',
+      city: 'St. Blanda Heath',
+      county: 'Cambridgeshire',
+      postalCode: 'YZ72 5MB',
+      country: 'United Kingdom',
+      uprn: null,
+      dependentLocality: null,
+      doubleDependentLocality: null,
+      typeId: null
+    },
+    doNotContact: false,
+    personalIdentifiers: null
+  },
+  businesses: [
+    {
+      name: 'Cliff Spence T/As Abbey Farm',
+      organisationId: '5625145',
+      sbi: '107591843'
+    }
+  ],
+  business: {
+    organisationId: '5625145',
+    sbi: '107591843',
+    name: 'Cliff Spence T/As Abbey Farm',
+    role: 'Employee',
+    messages: [
+      {
+        id: '11401',
+        subject: 'Permission changed for David Paul',
+        date: '2160-06-21T08:49:57.254Z',
+        body: '<p>Your permission for David Paul was changed on Sun Jan 22 2023</p>',
+        read: false,
+        deleted: false
+      },
+      {
+        id: '7551987',
+        subject: 'Permission changed for David Paul',
+        date: '2233-11-22T14:41:39.790Z',
+        body: '<p>Your permission for David Paul was changed on Thu Aug 17 2023</p>',
+        read: true,
+        deleted: false
+      },
+      {
+        id: '9315941',
+        subject: 'Permission changed for David Paul',
+        date: '2250-11-02T22:36:25.856Z',
+        body: '<p>Your permission for David Paul was changed on Thu Sep 07 2023</p>',
+        read: false,
+        deleted: true
+      }
+    ],
+    permissionGroups: [
+      {
+        id: 'BASIC_PAYMENT_SCHEME',
+        level: 'NO_ACCESS',
+        functions: []
+      },
+      {
+        id: 'BUSINESS_DETAILS',
+        level: 'AMEND',
+        functions: [
+          'View business details',
+          'View people associated with the business',
+          'Amend business and correspondence contact details'
+        ]
+      },
+      {
+        id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS',
+        level: 'SUBMIT',
+        functions: [
+          'View CS Agreements',
+          'View Land, Features and Cover',
+          'View CS Agreement amendments',
+          'View CS agreement Transfers',
+          'View CS Claims',
+          'Amend land, Features and Covers',
+          'Create and edit a CS claim',
+          'Amend a previously submitted claim',
+          'Create and edit a CS agreement Amendment',
+          'Revise a previously submitted agreement amendment',
+          'Create and Edit a CS agreement transfer',
+          'Revise a previously submitted agreement transfer',
+          'Submit Acceptance of CS Agreement offer',
+          'Submit rejection of CS agreement offer',
+          'Submit (and resubmit) a CS claim',
+          'Withdraw a CS claim',
+          'Submit (and resubmit) a CS agreement amendment',
+          'Withdraw a CS agreement amendment',
+          'Submit (and resubmit) a CS agreement transfer',
+          'Withdraw a CS agreement transfer',
+          'Receive warnings and notifications'
+        ]
+      },
+      {
+        id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS',
+        level: 'SUBMIT',
+        functions: [
+          'View CS Scheme eligibility',
+          'View Applications',
+          'View land, features and covers',
+          'View CS agreement offer',
+          'View draft CS Agreements',
+          'Create and edit a CS application',
+          'Amend a previously submitted CS application',
+          'Amend Land, Features and Covers',
+          'Submit CS Application',
+          'Withdraw CS application',
+          'Receive warnings and notifications'
+        ]
+      },
+      {
+        id: 'ENTITLEMENTS',
+        level: 'NO_ACCESS',
+        functions: []
+      },
+      {
+        id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS',
+        level: 'NO_ACCESS',
+        functions: []
+      },
+      {
+        id: 'LAND_DETAILS',
+        level: 'VIEW',
+        functions: ['View land, features and covers']
+      }
+    ]
+  },
+  authenticationQuestions: {
+    memorableDate: null,
+    memorableEvent: null,
+    memorableLocation: null,
+    updatedAt: null,
+    isFound: false
+  }
+}
+
+describe('Local mocked dev check', () => {
+  it('should support full business schema', async () => {
+    const query = gql`
+      query Business($sbi: ID!, $crn: ID!, $date: Date, $sheetId: ID!, $parcelId: ID!) {
+        business(sbi: $sbi) {
+          organisationId
+          sbi
+          info {
+            name
+            reference
+            vat
+            traderNumber
+            vendorNumber
+            address {
+              pafOrganisationName
+              line1
+              line2
+              line3
+              line4
+              line5
+              buildingNumberRange
+              buildingName
+              flatName
+              street
+              city
+              county
+              postalCode
+              country
+              uprn
+              dependentLocality
+              doubleDependentLocality
+              typeId
+            }
+            correspondenceAddress {
+              pafOrganisationName
+              line1
+              line2
+              line3
+              line4
+              line5
+              buildingNumberRange
+              buildingName
+              flatName
+              street
+              city
+              county
+              postalCode
+              country
+              uprn
+              dependentLocality
+              doubleDependentLocality
+              typeId
+            }
+            isCorrespondenceAsBusinessAddress
+            email {
+              address
+              validated
+            }
+            correspondenceEmail {
+              address
+              validated
+            }
+            phone {
+              mobile
+              landline
+            }
+            correspondencePhone {
+              mobile
+              landline
+            }
+            legalStatus {
+              code
+              type
+            }
+            type {
+              code
+              type
+            }
+            registrationNumbers {
+              companiesHouse
+              charityCommission
+            }
+            additionalSbis
+            lastUpdated
+            isFinancialToBusinessAddress
+            hasLandInNorthernIreland
+            hasLandInScotland
+            hasLandInWales
+            hasAdditionalBusinessActivities
+            additionalBusinessActivities {
+              code
+              type
+            }
+            isAccountablePeopleDeclarationComplete
+            dateStartedFarming
+            landConfirmed
+            status {
+              locked
+              confirmed
+              deactivated
+            }
+          }
+          customers {
+            personId
+            firstName
+            lastName
+            crn
+            role
+          }
+          customer(crn: $crn) {
+            personId
+            firstName
+            lastName
+            crn
+            role
+            permissionGroups {
+              id
+              level
+              functions
+            }
+          }
+          land {
+            summary {
+              arableLandArea
+              permanentCropsArea
+              permanentGrasslandArea
+              totalArea
+              totalParcels
+            }
+            parcelCovers(sheetId: $sheetId, parcelId: $parcelId, date: $date) {
+              id
+              name
+              area
+              code
+              isBpsEligible
+            }
+          }
+          countyParishHoldings {
+            cphNumber
+            parish
+            startDate
+            endDate
+            species
+            xCoordinate
+            yCoordinate
+            address
+          }
+          agreements {
+            contractId
+            name
+            status
+            contractType
+            schemeYear
+            startDate
+            endDate
+            paymentSchedules {
+              optionCode
+              optionDescription
+              commitmentGroupStartDate
+              commitmentGroupEndDate
+              year
+              sheetName
+              parcelName
+              actionArea
+              actionMTL
+              actionUnits
+              parcelTotalArea
+              startDate
+              endDate
+            }
+          }
         }
       }
-    }
-  }
-`
-
-describe('Local Dev Check', () => {
-  it('should return a valid response', async () => {
+    `
     const client = new GraphQLClient('http://localhost:3000/graphql')
-
     const response = await client.request(query, {
       sbi: '107183280',
+      crn: '9477368292',
+      date: '2020-01-01',
+      sheetId: 'SS6627',
+      parcelId: '8779'
+    })
+
+    expect(response).not.toHaveProperty('errors')
+    expect(response.business).toMatchObject({
+      ...business,
+      agreements: expect.arrayContaining([
+        { ...agreement, paymentSchedules: expect.arrayContaining(paymentSchedules) }
+      ])
+    })
+  })
+
+  it('should support full customer schema', async () => {
+    const query = gql`
+      query Customer($crn: ID!, $sbi: ID!) {
+        customer(crn: $crn) {
+          personId
+          crn
+          info {
+            name {
+              title
+              otherTitle
+              first
+              middle
+              last
+            }
+            dateOfBirth
+            phone {
+              mobile
+              landline
+            }
+            email {
+              address
+              validated
+            }
+            status {
+              locked
+              confirmed
+              deactivated
+            }
+            address {
+              pafOrganisationName
+              line1
+              line2
+              line3
+              line4
+              line5
+              buildingNumberRange
+              buildingName
+              flatName
+              street
+              city
+              county
+              postalCode
+              country
+              uprn
+              dependentLocality
+              doubleDependentLocality
+              typeId
+            }
+            doNotContact
+            personalIdentifiers
+          }
+          businesses {
+            name
+            organisationId
+            sbi
+          }
+          business(sbi: $sbi) {
+            organisationId
+            sbi
+            name
+            role
+            messages {
+              id
+              subject
+              date
+              body
+              read
+              deleted
+            }
+            permissionGroups {
+              id
+              level
+              functions
+            }
+          }
+          authenticationQuestions {
+            memorableDate
+            memorableEvent
+            memorableLocation
+            updatedAt
+            isFound
+          }
+        }
+      }
+    `
+    const client = new GraphQLClient('http://localhost:3000/graphql')
+    const response = await client.request(query, {
+      sbi: '107591843',
       crn: '0866159801'
     })
 
-    expect(response).toMatchObject({
-      business: expect.objectContaining({
-        organisationId: '5565448',
-        sbi: '107183280',
-        info: expect.objectContaining({ name: 'HENLEY, RE' }),
-        customer: expect.objectContaining({
-          personId: '5007136',
-          firstName: 'David',
-          lastName: 'Paul',
-          permissionGroups: expect.arrayContaining([
-            expect.objectContaining({
-              id: 'BUSINESS_DETAILS',
-              level: 'AMEND',
-              functions: expect.arrayContaining(['View business details'])
-            })
-          ])
-        })
-      })
-    })
+    expect(response).not.toHaveProperty('errors')
+    expect(response.customer).toEqual(customer)
   })
 })

--- a/test/graphql/full-schema.gql
+++ b/test/graphql/full-schema.gql
@@ -95,10 +95,10 @@ type PaymentSchedule {
   year: Int
   sheetName: String
   parcelName: String
-  actionArea: Int
+  actionArea: Float
   actionMTL: Int
   actionUnits: Int
-  parcelTotalArea: Int
+  parcelTotalArea: Float
   startDate: Date
   endDate: Date
 }

--- a/test/graphql/full-schema.gql
+++ b/test/graphql/full-schema.gql
@@ -193,6 +193,7 @@ type CustomerInfo {
   status: EntityStatus
   address: Address
   doNotContact: Boolean
+  personalIdentifiers: [String]
 }
 
 type CustomerName {

--- a/test/unit/logger/winstonFormatters.test.js
+++ b/test/unit/logger/winstonFormatters.test.js
@@ -113,6 +113,39 @@ describe('winstonFormatters', () => {
     })
   })
 
+  it('should handle request body as a string', () => {
+    const result = cdpSchemaTranslator().transform({
+      level: 'info',
+      message: 'test message',
+      request: { ...fixture.request, body: JSON.stringify(fixture.request.body) }
+    })
+    expect(result).toEqual({
+      level: 'info',
+      message: 'test message',
+      event: {
+        reference: 'http://localhost/path',
+        type: 'POST'
+      },
+      http: {
+        request: {
+          id: 'power-apps-req-id',
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer token',
+            email: 'probably.should@redacted.be',
+            'x-cdp-request-id': '00000000-0000-0000-0000-000000000000',
+            'x-ms-client-request-id': 'power-apps-req-id'
+          }
+        }
+      },
+      url: {
+        full: 'http://localhost/path',
+        query: 'searchFieldType=SBI&primarySearchPhrase=107183280&offset=0&limit=1'
+      }
+    })
+  })
+
   it('should return a reduced object when only partial info is provided', () => {
     expect(cdpSchemaTranslator().transform({ level: 'info', message: 'msg' })).toEqual({
       level: 'info',

--- a/test/unit/resolvers/business.test.js
+++ b/test/unit/resolvers/business.test.js
@@ -125,10 +125,10 @@ describe('Business', () => {
             year: '2020',
             sheet_name: 'mockSheetName',
             parcel_name: 'mockParcelName',
-            action_area: 100000,
+            action_area: 1654,
             action_mtl: 'mockActionMTL',
             action_units: 'mockActionUnits',
-            parcel_total_area: 100000,
+            parcel_total_area: 9876,
             payment_schedule_start_date: '2020-01-01T00:00:00.000Z',
             payment_schedule_end_date: '2020-12-31T00:00:00.000Z'
           }
@@ -158,10 +158,10 @@ describe('Business', () => {
             year: '2020',
             sheetName: 'mockSheetName',
             parcelName: 'mockParcelName',
-            actionArea: 10,
+            actionArea: 0.1654,
             actionMTL: 'mockActionMTL',
             actionUnits: 'mockActionUnits',
-            parcelTotalArea: 10,
+            parcelTotalArea: 0.9876,
             startDate: '2020-01-01T00:00:00.000Z',
             endDate: '2020-12-31T00:00:00.000Z'
           }

--- a/test/unit/resolvers/customer.test.js
+++ b/test/unit/resolvers/customer.test.js
@@ -2,24 +2,70 @@ import { jest } from '@jest/globals'
 
 import { Permissions } from '../../../app/data-sources/static/permissions.js'
 import { Customer, CustomerBusiness } from '../../../app/graphql/resolvers/customer/customer.js'
-import {
-  organisationPeopleByOrgId,
-  organisationPersonSummary
-} from '../../fixtures/organisation.js'
-import { personById } from '../../fixtures/person.js'
+import { organisationPeopleByOrgId } from '../../fixtures/organisation.js'
 import { buildPermissionsFromIdsAndLevels } from '../../test-helpers/permissions.js'
 
 const orgId = '5565448'
-const personId = '5007136'
-const personFixture = personById({ id: personId })
+const personFixture = {
+  id: 11111111,
+  title: 'Mrs.',
+  otherTitle: 'I',
+  firstName: 'Lauren',
+  middleName: 'Daryl',
+  lastName: 'Sanford',
+  dateOfBirth: 108901578380,
+  landline: '055 4582 4488',
+  mobile: '056 8967 5108',
+  email: 'lauren.sanford@immaculate-shark.info',
+  doNotContact: false,
+  emailValidated: false,
+  address: {
+    address1: '65',
+    address2: '1 McCullough Path',
+    address3: 'Newton Ratkedon',
+    address4: 'MS9 8BJ',
+    address5: 'North Macedonia',
+    pafOrganisationName: null,
+    flatName: null,
+    buildingNumberRange: null,
+    buildingName: null,
+    street: null,
+    city: 'Newton Bruen',
+    county: null,
+    postalCode: 'TC2 8KP',
+    country: 'Wales',
+    uprn: '790214962932',
+    dependentLocality: null,
+    doubleDependentLocality: null,
+    addressTypeId: null
+  },
+  locked: false,
+  confirmed: false,
+  customerReferenceNumber: 'crn-11111111',
+  personalIdentifiers: ['8568845789', '370030956', '7899566034'],
+  deactivated: false
+}
+const personBusinessesFixture = [
+  {
+    id: '5625145',
+    name: 'Cliff Spence T/As Abbey Farm',
+    sbi: 107591843,
+    additionalSbiIds: [],
+    confirmed: true,
+    lastUpdatedOn: null,
+    landConfirmed: null,
+    deactivated: false,
+    locked: false
+  }
+]
 
 const dataSources = {
   ruralPaymentsCustomer: {
     getCustomerByCRN() {
-      return personById({ id: personId })._data
+      return personFixture
     },
     getPersonBusinessesByPersonId() {
-      return organisationPersonSummary({ id: personId })._data
+      return personBusinessesFixture
     },
     getNotificationsByOrganisationIdAndPersonId: jest.fn(),
     getAuthenticateAnswersByCRN() {
@@ -45,48 +91,51 @@ describe('Customer', () => {
 
   test('Customer.info', async () => {
     const response = await Customer.info(
-      { crn: personFixture._data.customerReferenceNumber },
+      { crn: personFixture.customerReferenceNumber },
       undefined,
       { dataSources }
     )
 
     expect(response).toEqual({
       name: {
-        title: 'Dr.',
-        otherTitle: null,
-        first: 'David',
-        middle: 'Paul',
-        last: 'Paul'
+        title: 'Mrs.',
+        otherTitle: 'I',
+        first: 'Lauren',
+        middle: 'Daryl',
+        last: 'Sanford'
       },
-      dateOfBirth: '1947-10-30T03:41:25.385Z',
-      phone: { mobile: '1849164778', landline: null },
-      email: {
-        address: 'Selena_Kub@hotmail.com',
-        validated: false
-      },
+      dateOfBirth: '1973-06-14T10:26:18.380Z',
+      phone: { landline: '055 4582 4488', mobile: '056 8967 5108' },
+      email: { address: 'lauren.sanford@immaculate-shark.info', validated: false },
       doNotContact: false,
       address: {
+        line1: '65',
+        line2: '1 McCullough Path',
+        line3: 'Newton Ratkedon',
+        line4: 'MS9 8BJ',
+        line5: 'North Macedonia',
         pafOrganisationName: null,
-        buildingNumberRange: null,
-        buildingName: '853',
         flatName: null,
-        street: 'Zulauf Orchard',
-        city: 'St. Blanda Heath',
-        county: 'Cambridgeshire',
-        postalCode: 'YZ72 5MB',
-        country: 'United Kingdom',
-        uprn: null,
+        buildingNumberRange: null,
+        buildingName: null,
+        street: null,
+        city: 'Newton Bruen',
+        county: null,
+        postalCode: 'TC2 8KP',
+        country: 'Wales',
+        uprn: '790214962932',
         dependentLocality: null,
         doubleDependentLocality: null,
         typeId: null
       },
-      status: { locked: false, confirmed: false, deactivated: false }
+      status: { locked: false, confirmed: false, deactivated: false },
+      personalIdentifiers: ['8568845789', '370030956', '7899566034']
     })
   })
 
   test('Customer.business - returns null if no business', async () => {
     const response = await Customer.business(
-      { crn: personFixture._data.customerReferenceNumber },
+      { crn: personFixture.customerReferenceNumber },
       { sbi: 107183280 },
       { dataSources }
     )
@@ -95,14 +144,14 @@ describe('Customer', () => {
 
   test('Customer.business - returns business', async () => {
     const response = await Customer.business(
-      { crn: personFixture._data.customerReferenceNumber },
+      { crn: personFixture.customerReferenceNumber },
       { sbi: 107591843 },
       { dataSources }
     )
     expect(response).toEqual({
-      crn: '0866159801',
+      crn: 'crn-11111111',
       organisationId: '5625145',
-      personId: 5007136,
+      personId: 11111111,
       name: 'Cliff Spence T/As Abbey Farm',
       sbi: 107591843
     })
@@ -115,7 +164,7 @@ describe('Customer', () => {
         name: 'Cliff Spence T/As Abbey Farm',
         sbi: 107591843,
         organisationId: '5625145',
-        personId: 5007136,
+        personId: 11111111,
         crn: undefined
       }
     ])

--- a/test/unit/transformers/rural-payments-portal/busines.test.js
+++ b/test/unit/transformers/rural-payments-portal/busines.test.js
@@ -54,7 +54,6 @@ const organisation = {
   isCorrespondenceAsBusinessAddr: true,
   email: 'email address',
   emailValidated: true,
-  doNotContact: true,
   landline: 'landline',
   mobile: 'mobile',
   fax: 'fax',

--- a/test/unit/transformers/rural-payments/business.test.js
+++ b/test/unit/transformers/rural-payments/business.test.js
@@ -339,10 +339,10 @@ describe('Business transformer', () => {
             year: '2020',
             sheet_name: 'mockSheetName',
             parcel_name: 'mockParcelName',
-            action_area: 100000,
+            action_area: 1000,
             action_mtl: 'mockActionMTL',
             action_units: 'mockActionUnits',
-            parcel_total_area: 100000,
+            parcel_total_area: 100,
             payment_schedule_start_date: '2020-01-01T00:00:00:000+0100',
             payment_schedule_end_date: '2020-12-31T00:00:00:000+0100'
           }
@@ -368,10 +368,10 @@ describe('Business transformer', () => {
             year: '2020',
             sheetName: 'mockSheetName',
             parcelName: 'mockParcelName',
-            actionArea: 10,
+            actionArea: 0.1,
             actionMTL: 'mockActionMTL',
             actionUnits: 'mockActionUnits',
-            parcelTotalArea: 10,
+            parcelTotalArea: 0.01,
             startDate: '2020-01-01T00:00:00.000Z',
             endDate: '2020-12-31T00:00:00.000Z'
           }

--- a/test/unit/utils/number.test.js
+++ b/test/unit/utils/number.test.js
@@ -1,0 +1,18 @@
+import { convertSquareMetersToHectares } from '../../../app/utils/numbers'
+
+describe('#convertSquareMetersToHectares', () => {
+  it('should convert square meters to hectares', () => {
+    expect(convertSquareMetersToHectares(10_000)).toBe(1)
+    expect(convertSquareMetersToHectares(5_000)).toBe(0.5)
+    expect(convertSquareMetersToHectares(0)).toBe(0)
+    expect(convertSquareMetersToHectares(10_000.1)).toBe(1) // should round down sensibly
+    expect(convertSquareMetersToHectares(10_000.9)).toBe(1.0001) //should round up sensibly
+    expect(convertSquareMetersToHectares('10000')).toBe(1) // string input
+  })
+
+  it('should handle invalid inputs gracefully', () => {
+    expect(convertSquareMetersToHectares(null)).toBe(0) // null input
+    expect(convertSquareMetersToHectares(undefined)).toBe(0) // undefined input
+    expect(convertSquareMetersToHectares('invalid')).toBe(0) // non-numeric string
+  })
+})


### PR DESCRIPTION
Adds or enables all remaining customer data fields and makes them available to the gQL schema for client requests.
Extends the acceptance tests to comprehensively request full business/customer data.