### PR TITLE
fix: correct subjectId type

### DIFF
--- a/app/graphql/types/business/application.gql
+++ b/app/graphql/types/business/application.gql
@@ -15,7 +15,7 @@ type Application {
   """
   The unique identifier for the subject of this application.
   """
-  subjectId: Int @on
+  subjectId: ID @on
 
   """
   The year this application is for.

--- a/test/acceptance/local-dev-check.test.js
+++ b/test/acceptance/local-dev-check.test.js
@@ -264,7 +264,7 @@ const business = {
     {
       sbi: '107183280',
       id: '4511299240',
-      subjectId: 407841902,
+      subjectId: '407841902',
       year: 2022,
       name: 'COMMODO FACERE PARIATUR COGO CAREO VENTITO CONIECTO CUNABULA DEFETISCOR',
       moduleCode: 'CENTUM_UBERRIME_2022',

--- a/test/graphql/business.test.js
+++ b/test/graphql/business.test.js
@@ -438,7 +438,7 @@ describe('Query.business internal', () => {
             {
               sbi: 'sbi',
               id: 'app123',
-              subjectId: 123,
+              subjectId: '123',
               year: 2025,
               name: 'Application Name',
               moduleCode: 'Module Code',
@@ -591,7 +591,7 @@ describe('Query.business internal', () => {
             {
               sbi: 'sbi',
               id: 'app123',
-              subjectId: 123,
+              subjectId: '123',
               year: 2025,
               name: 'Application Name',
               moduleCode: 'Module Code',

--- a/test/graphql/full-schema.gql
+++ b/test/graphql/full-schema.gql
@@ -119,7 +119,7 @@ type PaymentSchedule {
 type Application {
   sbi: ID!
   id: ID!
-  subjectId: Int
+  subjectId: ID
   year: Int
   name: String
   moduleCode: String

--- a/test/graphql/partial-schema.gql
+++ b/test/graphql/partial-schema.gql
@@ -73,7 +73,7 @@ type PaymentSchedule {
 type Application {
   sbi: ID!
   id: ID!
-  subjectId: Int
+  subjectId: ID
   year: Int
   name: String
   moduleCode: String


### PR DESCRIPTION
Use the `ID` type for `subjectId` as it could be incompatible with the standard `Int32` expectations of JS integers.