### PR TITLE
docs: update advice for consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Data Access Layer (DAL) for the Farming and Countryside Programme (FCP) - a 
 
 ## Consumers' TL;DR
 
-This README was created for project contributors, as a consumer of the DAL API, you probably only care about the following quick start steps:
+This README was created for project contributors; as a potential consumer of the DAL API, you probably only care about the following quick start steps:
 
 ```bash
 curl https://raw.githubusercontent.com/DEFRA/fcp-dal-api/refs/heads/main/compose.yml -o dal-api-compose.yml
@@ -13,11 +13,12 @@ docker compose -f dal-api-compose.yml up
 
 The graphQL explorer should now be available, head to http://localhost:3000/graphql in your browser, and have a play!
 
-> NOTE: There are currently only 2 businesses in the mock, their SBIs are: `107183280` & `107591843`.
-> For composite queries (where a business and a customer reference are required), the CRNs `9477368292` & `0866159801` exist in both businesses.
+> NOTE: the IDs of the available customers and businesses can be found in the [mock code](https://github.com/DEFRA/fcp-dal-upstream-mock/blob/main/src/factories/id-lookups.js), along with their corresponding CRN or SBI (respectively), as well as the relationships between entities.
 
 > NOTE: The above is a simplified setup that is intended to aid consumer development.
 > For access to the live instances, [schema availability](#the-on-directive) and [authorisation](#security) would need to be carefully considered.
+
+More consumer focused documentation can be found on the project [Homepage...](https://defra.github.io/fcp-dal-api/homepage)
 
 ## Requirements
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,18 +1,29 @@
-# DAL Homepage
+# DAL Authentication
 
-The DAL requires multiple things to be provided to successfully return a response.
-**Please note in Dev the DAL has auth disabled so will return a response to all requests**
+The <abbr title="Data Access Layer">DAL</abbr> requires multiple things to be provided to successfully return a response.
+**Please note the DAL on the <abbr title="Core Delivery Platform">CDP</abbr> `dev` environment has auth _disabled_ so will return a response to all requests**
 
 ## Required for all requests
 
-- If making a request in a non-external environment (not ext-test or prod) you will need to either be within the CDP network or request your IP to be whitelisted.
-- You will need a valid Entra token that contains a group that has been provided and mapped to the corresponding access in the DAL.
+- If making a request from a DEFRA environment, you will need to either be within the CDP network or request your IP to be whitelisted.  
+  NOTE: the CDP `ext-test` and `prod` environments are externally accessible.
+- You will need a valid Entra token containing a group that has already been provided and mapped to the corresponding access in the DAL. This **POST** request shows how to get a token:
+  ```shell
+  curl --location 'https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token' \
+      --form 'client_id="{client_id}"' \
+      --form 'scope="{client_id}/.default"' \
+      --form 'client_secret="{client_secret}"' \
+      --form 'grant_type="client_credentials"'
+  ```
 
 ## Internal User requests
 
-- An email address of a user within the RP portal that has the correct permissions sent in the email header.
+- The email address of the user making the request, sent in the `email` header.  
+  NOTE: This email must match an account on the RP portal (with the correct permissions)
 
 ## External User requests
 
-- Set **gateway-type** header to "external"
-- A Defra ID token that contains the relevant CRN and SBI (if requesting business data) for your query sent through in the **x-forwarded-authorization** header
+- Set `gateway-type` header to "**external**"
+- Set `x-forwarded-authorization` header to a Defra ID token that contains the relevant <abbr title="Customer Reference Number">CRN</abbr> and <abbr title="Single Business Identifier">SBI</abbr> (if requesting business data)
+
+[< back to Homepage](./homepage)

--- a/docs/homepage.md
+++ b/docs/homepage.md
@@ -2,41 +2,33 @@
 
 ## Environments
 
-The DAL has the following environments:
-| DAL Env | URL | Azure Entra Tenant - Tenant ID | KITS/Version1/RP Portal Env |
-| ----------| ------------- | ----- | ------- |
-| Dev | https://fcp-dal-api.dev.cdp-int.defra.cloud/graphql | No Auth required | Upstream mock - dev |
-| Test | https://fcp-dal-api.test.cdp-int.defra.cloud/graphql | O365_DEFRADEV - 6f504113-6b64-43f2-ade9-242e05780007 | Upgrade |
-| Ext-test | https://et.fcp-dal.api.defra.gov.uk/graphql | Defra - 770a2450-0227-4c62-90c7-4e38537f1102 | Perf |
-| Perf-test | https://fcp-dal-api.perf-test.cdp-int.defra.cloud/graphql | Defra - 770a2450-0227-4c62-90c7-4e38537f1102 | Upstream mock - perf-test |
-| Prod | https://fcp-dal-api.defra.gov.uk/graphql | Defra - 770a2450-0227-4c62-90c7-4e38537f1102 | Prod |
+The <abbr title="Data Access Layer">DAL</abbr> has the following environments:
+
+| DAL Env   | URL                                                       | Azure Entra Tenant | KITS/Version1/RP Portal Env |
+| --------- | --------------------------------------------------------- | ------------------ | --------------------------- |
+| Dev       | https://fcp-dal-api.dev.cdp-int.defra.cloud/graphql       | No auth required   | Upstream mock - dev         |
+| Test      | https://fcp-dal-api.test.cdp-int.defra.cloud/graphql      | O365_DEFRADEV      | Upgrade                     |
+| Ext-test  | https://et.fcp-dal.api.defra.gov.uk/graphql               | Defra              | Perf                        |
+| Perf-test | https://fcp-dal-api.perf-test.cdp-int.defra.cloud/graphql | Defra              | Upstream mock - perf-test   |
+| Prod      | https://fcp-dal-api.defra.gov.uk/graphql                  | Defra              | Prod                        |
+
+> NOTE: the Tenant ID for Test is `6f504113-6b64-43f2-ade9-242e05780007` (O365_DEFRADEV), all higher environments use the Prod DEFRA Tenant `770a2450-0227-4c62-90c7-4e38537f1102`
 
 ## Onboarding
 
 The DAL requires a few things:
 
 - Entra Security Group in the corresponding tenant for the DAL
-- An App reg in your group to generate the token, with the groups exposed in the token
-- Have the Group added to the DAL to provide access to the necessary fields (we do not currently use service accounts to call our upstreams as this is a WIP)
+- An "App Reg" in your Group to generate the auth token, with the groups exposed in the token
+- Supply the Group ID to the DAL Team to provide access to the necessary fields (we do not currently use service accounts to call our upstreams as this is a WIP)
 - A valid user email or Defra ID token for the user making the request for your service
-  - **If Your service users do not have access to the RP Portal you will not be able to use the DAL currently**
+  - **If your service users do not have access to the RP Portal you will not be able to use the DAL currently**
 
-**Note:** you must also request the app reg be updated to expose the security groups in the token, this is done by setting the following in the manifest json:
+**Note:** you must also request the app reg be updated to expose the security groups in the token, this is done by setting the following in the manifest JSON:
 `"groupMembershipClaims": "SecurityGroup",`
 
-So if your service is looking to connect to the Test environment you will need an app reg and Entra group created in the O365_DEFRADEV Azure tenant.
+Example: if your service is looking to connect to the Test environment you will need an App Reg and Entra Group created in the `O365_DEFRADEV` Azure tenant.
 
-### Authenticating
+## Authenticating
 
-All DAL environments other than Dev require a valid Microsoft OIDC token containing Groups that have been mapped withing the DAL to the corresponding access.
-
-Your service will then need to generate a valid OIDC token containing the group claims,
-you can do this by making the following POST request:
-
-```shell
-curl --location 'https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token' \
-  --form 'client_id="{client_id}"' \
-  --form 'scope="{client_id}/.default"' \
-  --form 'client_secret="{client_secret}"' \
-  --form 'grant_type="client_credentials"'
-```
+All DAL environments (except Dev) require a valid Microsoft OIDC token (with the Group setup as described in the [Onboarding](#Onboarding) section above). There are also some other requirements depending on the type of request, please see the [DAL Authentication](./auth) guide for details.


### PR DESCRIPTION
- Correct out-dated README content, and point consumers to the newer github project Homepage resources.
- Reduce the Homepage env table content to better fit the narrow scheme, and move the bulk of the Authenticating section to the dedicated sub-page.
- Add the auth token example from the Homepage to the auth sub-page, and consolidate the advice.
- Add better linking between the 2 project docs pages and the main README.

Jira task [FCPDAL-110]

[FCPDAL-110]: https://eaflood.atlassian.net/browse/FCPDAL-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ