### PR TITLE
chore: fix tagging on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,13 +27,24 @@ jobs:
 
       - name: Discover version number
         id: version
-        run: echo "value=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          if git ls-remote --tags origin "refs/tags/${VERSION}" | grep -q "${VERSION}"; then
+            echo "Tag ${VERSION} already exists"
+            exit 1
+          fi
+          echo "value=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Build and Publish
         uses: DEFRA/cdp-build-action/build@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.version.outputs.value }}
+
+      - name: Tag repository
+        run: |
+          git tag ${{ steps.version.outputs.value }}
+          git push --tags
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@apollo/datasource-rest": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/unit/data-sources/rural-payments/rural-payments-business.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments-business.test.js
@@ -456,7 +456,12 @@ describe('Rural Payments Business', () => {
       expect(httpGet).toHaveBeenCalledWith(
         'SitiAgriApi/cv/landUseByBusinessParcel/sheet/mockSheetId/parcel/mockParcelId/sbi/mockSbi/list',
         {
-          params: { pointInTime: new Date().toISOString().replace('T', ' ').substring(0, 19) }
+          params: {
+            pointInTime: new Date()
+              // "sv" locale, with this timezone, creates an ISO formatted date string, but in the
+              // correct timezone (i.e. BST aware)
+              .toLocaleString('sv', { timeZone: 'Europe/London' })
+          }
         }
       )
     })


### PR DESCRIPTION
The cdp-build-action does not automatically tag the repo with the latest version, when we supply a custom version, so we need to explicitly create the tag.
Also added a check that the tag does not already exist, so that we fail-fast

This relates to Jira ticket: [FCPDAL-4]


[FCPDAL-4]: https://eaflood.atlassian.net/browse/FCPDAL-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ