### PR TITLE
fix: handle 0 and null returns in convertSquareMetresToHectares

### DIFF
--- a/app/utils/numbers.js
+++ b/app/utils/numbers.js
@@ -1,6 +1,6 @@
 const squareMetersToHectares = 0.0001
 
 export const convertSquareMetersToHectares = (area) => {
-  const result = parseFloat((parseFloat(area) * squareMetersToHectares).toFixed(4))
-  return isNaN(result) ? null : result
+  const result = Number.parseFloat((Number.parseFloat(area) * squareMetersToHectares).toFixed(4))
+  return Number.isNaN(result) ? null : result
 }

--- a/app/utils/numbers.js
+++ b/app/utils/numbers.js
@@ -1,3 +1,3 @@
 const squareMetersToHectares = 0.0001
 export const convertSquareMetersToHectares = (area) =>
-  parseFloat((parseFloat(area) * squareMetersToHectares).toFixed(4)) || 0
+  parseFloat((parseFloat(area) * squareMetersToHectares).toFixed(4)) || null

--- a/app/utils/numbers.js
+++ b/app/utils/numbers.js
@@ -1,3 +1,6 @@
 const squareMetersToHectares = 0.0001
-export const convertSquareMetersToHectares = (area) =>
-  parseFloat((parseFloat(area) * squareMetersToHectares).toFixed(4)) || null
+
+export const convertSquareMetersToHectares = (area) => {
+  const result = parseFloat((parseFloat(area) * squareMetersToHectares).toFixed(4))
+  return isNaN(result) ? null : result
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@apollo/datasource-rest": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/unit/utils/number.test.js
+++ b/test/unit/utils/number.test.js
@@ -4,10 +4,13 @@ describe('#convertSquareMetersToHectares', () => {
   it('should convert square meters to hectares', () => {
     expect(convertSquareMetersToHectares(10_000)).toBe(1)
     expect(convertSquareMetersToHectares(5_000)).toBe(0.5)
-    expect(convertSquareMetersToHectares(0)).toBe(null)
     expect(convertSquareMetersToHectares(10_000.1)).toBe(1) // should round down sensibly
     expect(convertSquareMetersToHectares(10_000.9)).toBe(1.0001) //should round up sensibly
     expect(convertSquareMetersToHectares('10000')).toBe(1) // string input
+  })
+
+  it('should return 0 if the original value was 0', () => {
+    expect(convertSquareMetersToHectares(0)).toBe(0)
   })
 
   it('should handle invalid inputs gracefully', () => {

--- a/test/unit/utils/number.test.js
+++ b/test/unit/utils/number.test.js
@@ -4,15 +4,15 @@ describe('#convertSquareMetersToHectares', () => {
   it('should convert square meters to hectares', () => {
     expect(convertSquareMetersToHectares(10_000)).toBe(1)
     expect(convertSquareMetersToHectares(5_000)).toBe(0.5)
-    expect(convertSquareMetersToHectares(0)).toBe(0)
+    expect(convertSquareMetersToHectares(0)).toBe(null)
     expect(convertSquareMetersToHectares(10_000.1)).toBe(1) // should round down sensibly
     expect(convertSquareMetersToHectares(10_000.9)).toBe(1.0001) //should round up sensibly
     expect(convertSquareMetersToHectares('10000')).toBe(1) // string input
   })
 
   it('should handle invalid inputs gracefully', () => {
-    expect(convertSquareMetersToHectares(null)).toBe(0) // null input
-    expect(convertSquareMetersToHectares(undefined)).toBe(0) // undefined input
-    expect(convertSquareMetersToHectares('invalid')).toBe(0) // non-numeric string
+    expect(convertSquareMetersToHectares(null)).toBe(null) // null input
+    expect(convertSquareMetersToHectares(undefined)).toBe(null) // undefined input
+    expect(convertSquareMetersToHectares('invalid')).toBe(null) // non-numeric string
   })
 })


### PR DESCRIPTION
This fixes/resolves/relates to Jira ticket: [FCPDAL-307]

**convertSquareMetresToHectares**

- If value of 0 returned from endpoint, 0 should show
- If value >0 returned from endpoint, this should be converted from m2 to hectares (by dividing by 10,000)
- If value is null/undefined/etc returned from endpoint, blank (i.e. null) should show


[FCPDAL-307]: https://eaflood.atlassian.net/browse/FCPDAL-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ