### PR TITLE
fix: intermittent failure on server test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@apollo/datasource-rest": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/graphql/makeTestQuery.js
+++ b/test/graphql/makeTestQuery.js
@@ -9,11 +9,12 @@ export const makeTestQuery = async (
   headers,
   isAuthenticated = true,
   variableValues = {},
-  authGroups = []
+  authGroups = [],
+  dropDbOnCompletion = true
 ) => {
   const ctx = await context({ request: { headers: headers ?? defaultHeaders } })
   try {
-    const response = await graphql({
+    return await graphql({
       source,
       schema: await createSchema(),
       contextValue: {
@@ -24,8 +25,9 @@ export const makeTestQuery = async (
       },
       variableValues
     })
-    return response
   } finally {
-    await ctx.db.dropDatabase()
+    if (dropDbOnCompletion) {
+      await ctx.db.dropDatabase()
+    }
   }
 }

--- a/test/graphql/mutation/business-create.test.js
+++ b/test/graphql/mutation/business-create.test.js
@@ -1,8 +1,10 @@
 import nock from 'nock'
 import { config } from '../../../app/config.js'
+import { db } from '../../../app/mongo.js'
 import { transformBusinessDetailsToOrgDetailsCreate } from '../../../app/transformers/rural-payments/business.js'
 import { mockPersonSearch } from '../helpers.js'
 import { makeTestQuery } from '../makeTestQuery.js'
+import { waitFor } from '../../test-helpers/wait-for.js'
 
 const v1 = nock(config.get('kits.internal.gatewayUrl'))
 
@@ -152,19 +154,32 @@ mutation CreateBusiness($input: CreateBusinessInput!) {
 }
 `
 
+// retrievePersonIdByCRN fires a MongoDB insert without awaiting it to avoid slowing down the
+// request. In tests this means a potential race condition between the insert and the database cleanup.
+// For safety, we should wait for the insert complete  (allowing the db to be torn down in the afterEach)
+const waitForPersonIdToBeCachedInMongo = async () => {
+  await waitFor(async () => {
+    const cached = await db.collection('customers').findOne({ _id: 'crn' })
+    expect(cached?.personId).toBe('personId')
+  })
+}
+
 //  Nock is setup separately in each test to ensure the order and number of requests is as expected
 describe('business', () => {
-  afterEach(() => {
+  afterEach(async () => {
     nock.cleanAll()
     nock.enableNetConnect()
+    await db.dropDatabase()
   })
 
   beforeEach(setupNock)
 
   test('create a business - withoutUprn', async () => {
-    const result = await makeTestQuery(query, null, true, { input })
+    const result = await makeTestQuery(query, null, true, { input }, [], false)
 
     expect(nock.isDone()).toBe(true)
+
+    await waitForPersonIdToBeCachedInMongo()
 
     expect(result).toEqual({
       data: {
@@ -268,7 +283,7 @@ describe('business', () => {
         withUprn: { ...input.correspondenceAddress.withoutUprn, uprn: '123456789012' }
       }
     }
-    const result = await makeTestQuery(query, null, true, { input: inputWithUprn })
+    const result = await makeTestQuery(query, null, true, { input: inputWithUprn }, [], false)
 
     expect(result).toEqual({
       data: {

--- a/test/test-helpers/wait-for.js
+++ b/test/test-helpers/wait-for.js
@@ -1,0 +1,23 @@
+/**
+ * Retries a callback until it passes or the timeout expires.
+ * The function passes if it completes without throwing an error, no return value is
+ * expected, or asserted against.
+ *
+ * @param callbackFunction function to call.
+ * @param timeout the maximum length of time (in milliseconds) to wait for a response
+ * @param interval the number of milliseconds between retry events
+ */
+
+export const waitFor = async (callbackFunction, { timeout = 5000, interval = 200 } = {}) => {
+  const deadline = Date.now() + timeout
+  let lastError
+  while (Date.now() < deadline) {
+    try {
+      return await callbackFunction()
+    } catch (err) {
+      lastError = err
+      await new Promise((resolve) => setTimeout(resolve, interval))
+    }
+  }
+  throw lastError
+}

--- a/test/unit/integration/narrow/app/server.test.js
+++ b/test/unit/integration/narrow/app/server.test.js
@@ -35,7 +35,7 @@ describe('Server config and startup', () => {
   let configMockPath
   beforeEach(async () => {
     configMockPath = {
-      PORT: '3000',
+      port: '3987',
       requestTimeoutMs: timeout
     }
     const originalConfig = { ...config }
@@ -61,10 +61,12 @@ describe('Server config and startup', () => {
 
     test('idle socket should be closed by timeout', () => {
       return new Promise((resolve, reject) => {
-        const socket = net.connect({ port: config.get('PORT') })
+        const socket = net.connect({ port: config.get('port') })
         socket.on('connect', socketTimeoutTest(socket, reject))
         socket.on('close', resolve)
-        socket.on('error', console.error)
+        socket.on('error', () => {
+          throw new Error('Failed to obtain server connection')
+        })
       })
     })
 


### PR DESCRIPTION
## Fixes for two intermittent test failures

### Server.test.js

There were two key issues with this test
* Test started server on default hapi port (4000), due to incorrect port lookup in beforeEach - “PORT” vs “port” 
* The test itself tried to connect on the “PORT” defined in the test (3000), not the same port that we started above

This leads to different results.

- Running on CLI (or locally with nothing bound to port 3000)
    - The test runs green, we didn’t get a connection, but there was no guard against that scenario, the tests exits without asserting anything 

 - Running locally, with some external process (bound to port 3000, e.g. CV, DAL)
   - The test fails this time
	- Successfully obtains a connection to the server running on 3000. 
	- This server has not been configured with the short timeout that this test expects
	- Test throws “Socket not closed after timeout”


Fixes:
- Use a port that is unlikely to be in use
- Ensure both server startup and client connect both use this port
- Ensure that if client connect fails to obtain a connection, then the test fails

### Race condition in business-create tests

* This test calls makeTestQuery with a query that has a side-effect of inserting a person into mongo.  At the end of makeTestQuery, the database is dropped.
* This insert into mongo is fire-and-forget, so may not actually have completed before the database is dropped
* There is a potential race condition between the insert and tear-down, causing unpredictable results as the two tests in this suite appear to interfere with each other.

The safest approach here is for the test (and database teardown) not to complete until the fire-and-forget insert has actually completed.
The steps to achieve this are
* Add a param to makeTestQuery to allow the database teardown to be deferred 
* Add a waitFor(..) function to allow the side-effect to to be asserted (while still gracefully failing after a period of time)
    * Created this as a re-usable function as we don’t have any libraries in the codebase providing this , but it’s useful to have)
* In this test suite
    * Defer the teardown until the afterEach block
    * Add a wait for the personId to have been added
        * It’s now safe to complete the test, no incomplete inserts will leak out of the test

This was discovered while investigating https://eaflood.atlassian.net/browse/FCPDAL-109
