### PR TITLE
Feat/ecs logging improvements

### DIFF
--- a/app/data-sources/BaseRESTDataSource.js
+++ b/app/data-sources/BaseRESTDataSource.js
@@ -26,7 +26,7 @@ export class BaseRESTDataSource extends RESTDataSource {
     this.logger.error(`#datasource - ${this.name} - request error`, {
       error,
       request,
-      response: { ...error?.extensions?.response },
+      response: { statusCode: error?.extensions?.response?.status },
       code: this.code
     })
   }
@@ -97,6 +97,7 @@ export class BaseRESTDataSource extends RESTDataSource {
       request: { ...request, path: url.toString() },
       response: {
         ...response,
+        statusCode: response?.status,
         body: result.parsedBody,
         size: Buffer.byteLength(JSON.stringify(response.body))
       },

--- a/app/data-sources/BaseRESTDataSource.js
+++ b/app/data-sources/BaseRESTDataSource.js
@@ -12,7 +12,7 @@ export class BaseRESTDataSource extends RESTDataSource {
   }
 
   didEncounterError(error, request, url) {
-    request.path = url
+    request.url = url
     if (!error) {
       error = { message: 'unknown/empty error while trying to fetch upstream data' }
     }
@@ -21,13 +21,12 @@ export class BaseRESTDataSource extends RESTDataSource {
       message += ` | Caused by ${cause.constructor.name}: ${cause.message}`
       cause = cause.cause
     }
-
     error.message = message
 
     this.logger.error(`#datasource - ${this.name} - request error`, {
       error,
       request,
-      response: { statusCode: error?.extensions?.response?.status },
+      response: { ...error?.extensions?.response },
       code: this.code
     })
   }
@@ -92,13 +91,12 @@ export class BaseRESTDataSource extends RESTDataSource {
         headers: request.headers,
         url: url.toString()
       },
-      response: { statusCode: response?.status }
+      response
     })
     this.logger.debug(`#datasource - ${this.name} - response detail`, {
       request: { ...request, url: url.toString() },
       response: {
         ...response,
-        statusCode: response?.status,
         body: result.parsedBody,
         size: Buffer.byteLength(JSON.stringify(response.body))
       },

--- a/app/data-sources/BaseRESTDataSource.js
+++ b/app/data-sources/BaseRESTDataSource.js
@@ -21,6 +21,7 @@ export class BaseRESTDataSource extends RESTDataSource {
       message += ` | Caused by ${cause.constructor.name}: ${cause.message}`
       cause = cause.cause
     }
+
     error.message = message
 
     this.logger.error(`#datasource - ${this.name} - request error`, {
@@ -54,7 +55,7 @@ export class BaseRESTDataSource extends RESTDataSource {
     await this.addAuthentication(request)
 
     this.logger.debug(`#datasource - ${this.name} - request`, {
-      request: { ...request, path: path.toString() },
+      request: { ...request, url: `${this.baseURL}${path}` },
       code: this.code
     })
   }
@@ -89,12 +90,12 @@ export class BaseRESTDataSource extends RESTDataSource {
         id: request.id,
         method: request.method.toUpperCase(),
         headers: request.headers,
-        path: url.toString()
+        url: url.toString()
       },
       response: { statusCode: response?.status }
     })
     this.logger.debug(`#datasource - ${this.name} - response detail`, {
-      request: { ...request, path: url.toString() },
+      request: { ...request, url: url.toString() },
       response: {
         ...response,
         statusCode: response?.status,

--- a/app/logger/winstonFormatters.js
+++ b/app/logger/winstonFormatters.js
@@ -82,7 +82,15 @@ const buildUrl = ({ body, path }) => {
   const result = {}
 
   if (path) {
-    result.full = path
+    const pathStr = path.toString()
+    if (pathStr.startsWith('http')) {
+      result.full = pathStr
+      result.path = new URL(pathStr).pathname
+    } else {
+      result.path = pathStr
+      // Not strictly the full path, but populated with best endeavours
+      result.full = pathStr
+    }
   }
 
   if (body) {

--- a/app/logger/winstonFormatters.js
+++ b/app/logger/winstonFormatters.js
@@ -10,12 +10,13 @@ const buildHttpDetails = (request, response, requestTimeMs) => {
       ...(request?.method && { method: request.method }),
       ...(request?.headers && { headers: request.headers })
     }
-  if (response || requestTimeMs)
+  if (response || requestTimeMs) {
+    const statusCode = response?.statusCode || response?.status
     http.response = {
-      ...(response?.statusCode && { status_code: response.statusCode }),
+      ...(statusCode && { status_code: statusCode }),
       ...(requestTimeMs && { response_time: requestTimeMs })
     }
-
+  }
   return { http }
 }
 

--- a/app/logger/winstonFormatters.js
+++ b/app/logger/winstonFormatters.js
@@ -78,18 +78,25 @@ const pickKeysForLogging = (obj) => {
   return picked
 }
 
-const buildUrl = ({ body, path }) => {
+const buildUrl = ({ body, path, url }) => {
   const result = {}
 
-  if (path) {
-    const pathStr = path.toString()
-    if (pathStr.startsWith('http')) {
-      result.full = pathStr
-      result.path = new URL(pathStr).pathname
-    } else {
-      result.path = pathStr
-      // Not strictly the full path, but populated with best endeavours
-      result.full = pathStr
+  if (url && path) {
+    // Simplest case, both fields supplied, no interpretation needed
+    result.full = url
+    result.path = path
+  } else {
+    const pathToUse = url || path
+    if (pathToUse) {
+      const pathStr = pathToUse.toString()
+      if (pathStr.startsWith('http')) {
+        result.full = pathStr
+        result.path = new URL(pathStr).pathname
+      } else {
+        result.path = pathStr
+        // Not strictly the full path, but populated with best endeavours
+        result.full = pathStr
+      }
     }
   }
 

--- a/app/server.js
+++ b/app/server.js
@@ -34,6 +34,7 @@ server.ext({
         id: request.traceId,
         method: request.method.toUpperCase(),
         path: request.path,
+        url: `${server.info.uri}${request.path}`,
         params: request.params,
         payload: request.payload,
         body: request.body,
@@ -67,7 +68,7 @@ server.events.on('response', function (request) {
       request: {
         id: request.traceId,
         method: request.method.toUpperCase(),
-        path: request.path,
+        url: `${server.info.uri}${request.path}`,
         params: request.params,
         payload: request.payload,
         body: request.body,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@apollo/datasource-rest": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/unit/data-sources/BaseRESTDataSource.test.js
+++ b/test/unit/data-sources/BaseRESTDataSource.test.js
@@ -43,12 +43,24 @@ describe('BaseRESTDataSource', () => {
       expect(mockRequest.path).toBe(mockUrl)
       expect(mockLogger.error).toHaveBeenCalledWith(
         '#datasource - Test DataSource - request error',
-        {
+        expect.objectContaining({
           error: mockError,
           request: mockRequest,
-          response: {},
           code: 'TEST_001'
-        }
+        })
+      )
+    })
+
+    test('should log the upstream response status code from error extensions', () => {
+      const mockError = new Error('Upstream error')
+      mockError.extensions = { response: { status: 503 } }
+      const mockRequest = { headers: {} }
+
+      dataSource.didEncounterError(mockError, mockRequest, 'https://api.example.com/test')
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ response: { statusCode: 503 } })
       )
     })
 

--- a/test/unit/data-sources/BaseRESTDataSource.test.js
+++ b/test/unit/data-sources/BaseRESTDataSource.test.js
@@ -40,7 +40,7 @@ describe('BaseRESTDataSource', () => {
 
       dataSource.didEncounterError(mockError, mockRequest, mockUrl)
 
-      expect(mockRequest.path).toBe(mockUrl)
+      expect(mockRequest.url).toBe(mockUrl)
       expect(mockLogger.error).toHaveBeenCalledWith(
         '#datasource - Test DataSource - request error',
         expect.objectContaining({
@@ -60,7 +60,7 @@ describe('BaseRESTDataSource', () => {
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.any(String),
-        expect.objectContaining({ response: { statusCode: 503 } })
+        expect.objectContaining({ response: { status: 503 } })
       )
     })
 
@@ -70,7 +70,7 @@ describe('BaseRESTDataSource', () => {
 
       dataSource.didEncounterError(null, mockRequest, mockUrl)
 
-      expect(mockRequest.path).toBe(mockUrl)
+      expect(mockRequest.url).toBe(mockUrl)
       expect(mockLogger.error).toHaveBeenCalledWith(
         '#datasource - Test DataSource - request error',
         expect.objectContaining({

--- a/test/unit/data-sources/rural-payments/rural-payments.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments.test.js
@@ -149,7 +149,7 @@ describe('RuralPayments', () => {
 
       expect(request.headers).toEqual({ email: 'test@test.test', 'gateway-type': 'internal' })
       expect(logger.debug).toHaveBeenCalledWith('#datasource - Rural payments - request', {
-        request: { ...request, path: 'test-path' },
+        request: { ...request, url: 'https://rp_kits_gateway_internal_url/test-path' },
         code: RURALPAYMENTS_API_REQUEST_001
       })
     })
@@ -180,7 +180,7 @@ describe('RuralPayments', () => {
         crn: 'test-crn'
       })
       expect(logger.debug).toHaveBeenCalledWith('#datasource - Rural payments - request', {
-        request: { ...request, path: 'test-path' },
+        request: { ...request, url: 'https://rp_kits_gateway_external_url/test-path' },
         code: RURALPAYMENTS_API_REQUEST_001
       })
     })
@@ -312,7 +312,7 @@ describe('RuralPayments', () => {
             id: '123',
             method: 'GET',
             headers: {},
-            path: 'test-url'
+            url: 'test-url'
           },
           response: { statusCode: 200 }
         })
@@ -320,7 +320,7 @@ describe('RuralPayments', () => {
       expect(logger.debug).toHaveBeenCalledWith(
         '#datasource - Rural payments - response detail',
         expect.objectContaining({
-          request: { ...request, path: 'test-url' },
+          request: { ...request, url: 'test-url' },
           response: expect.objectContaining({
             body: { data: 'test' }
           }),

--- a/test/unit/data-sources/rural-payments/rural-payments.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments.test.js
@@ -93,7 +93,7 @@ describe('RuralPayments', () => {
       expect(logger.error).toHaveBeenCalledWith('#datasource - Rural payments - request error', {
         error,
         request,
-        response: error.extensions.response,
+        response: { statusCode: 400 },
         code: RURALPAYMENTS_API_REQUEST_001
       })
     })
@@ -105,7 +105,7 @@ describe('RuralPayments', () => {
       const intermediateError = new TypeError('intermediate cause')
       intermediateError.cause = new Error('root cause error')
       error.cause = intermediateError
-      // error.extensions = { response: { status: 400, headers: { get: () => 'text/html' } } }
+      error.extensions = { response: { status: 500 } }
       const request = {}
       const url = 'test url'
 
@@ -116,7 +116,7 @@ describe('RuralPayments', () => {
           'test error | Caused by TypeError: intermediate cause | Caused by Error: root cause error'
         ),
         request,
-        response: {},
+        response: { statusCode: 500 },
         code: RURALPAYMENTS_API_REQUEST_001
       })
     })

--- a/test/unit/data-sources/rural-payments/rural-payments.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments.test.js
@@ -93,7 +93,7 @@ describe('RuralPayments', () => {
       expect(logger.error).toHaveBeenCalledWith('#datasource - Rural payments - request error', {
         error,
         request,
-        response: { statusCode: 400 },
+        response: error.extensions.response,
         code: RURALPAYMENTS_API_REQUEST_001
       })
     })
@@ -116,7 +116,7 @@ describe('RuralPayments', () => {
           'test error | Caused by TypeError: intermediate cause | Caused by Error: root cause error'
         ),
         request,
-        response: { statusCode: 500 },
+        response: error.extensions.response,
         code: RURALPAYMENTS_API_REQUEST_001
       })
     })
@@ -314,7 +314,7 @@ describe('RuralPayments', () => {
             headers: {},
             url: 'test-url'
           },
-          response: { statusCode: 200 }
+          response: mockResult.response
         })
       )
       expect(logger.debug).toHaveBeenCalledWith(

--- a/test/unit/logger/winstonFormatters.test.js
+++ b/test/unit/logger/winstonFormatters.test.js
@@ -111,6 +111,7 @@ describe('winstonFormatters', () => {
         tenant: { id: 'tenant-id', message: 'some tenant info' },
         url: {
           full: 'http://localhost/path',
+          path: '/path',
           query: '{"searchFieldType":"SBI","primarySearchPhrase":"107183280"}'
         }
       })
@@ -145,6 +146,7 @@ describe('winstonFormatters', () => {
       },
       url: {
         full: 'http://localhost/path',
+        path: '/path',
         query: '{"searchFieldType":"SBI","primarySearchPhrase":"107183280"}'
       }
     })
@@ -236,6 +238,42 @@ describe('winstonFormatters', () => {
         sbi: '987654321',
         primarySearchPhrase: 'jane doe'
       })
+    })
+  })
+
+  describe('buildUrl', () => {
+    it('sets url.full and url.path when request.path is a full URL string', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: { path: 'https://api.example.com/organisation/123' }
+      })
+      expect(result.url).toEqual({
+        full: 'https://api.example.com/organisation/123',
+        path: '/organisation/123'
+      })
+    })
+
+    it('sets url.full and url.path when request.path is a URL object', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: { path: new URL('https://api.example.com/organisation/123') }
+      })
+      expect(result.url).toEqual({
+        full: 'https://api.example.com/organisation/123',
+        path: '/organisation/123'
+      })
+    })
+
+    it('sets url.path (and url.full for completeness, even though it`s not a full path) when request.path is a path-only string', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: { path: '/organisation/123' }
+      })
+      expect(result.url).toEqual({ full: '/organisation/123', path: '/organisation/123' })
+    })
+
+    it('sets no url field when request has no path', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: { method: 'GET' }
+      })
+      expect(result.url).not.toBeDefined()
     })
   })
 })

--- a/test/unit/logger/winstonFormatters.test.js
+++ b/test/unit/logger/winstonFormatters.test.js
@@ -184,6 +184,29 @@ describe('winstonFormatters', () => {
     })
   })
 
+  describe('buildHttpDetails', () => {
+    it('uses response.statusCode for status_code when present', () => {
+      const result = cdpSchemaTranslator().transform({
+        response: { statusCode: 201 }
+      })
+      expect(result.http.response.status_code).toBe(201)
+    })
+
+    it('falls back to response.status for status_code when statusCode is absent', () => {
+      const result = cdpSchemaTranslator().transform({
+        response: { status: 404 }
+      })
+      expect(result.http.response.status_code).toBe(404)
+    })
+
+    it('omits status_code when neither statusCode nor status is present', () => {
+      const result = cdpSchemaTranslator().transform({
+        response: { body: 'something' }
+      })
+      expect(result.http.response).not.toHaveProperty('status_code')
+    })
+  })
+
   describe('pickKeysForLogging ', () => {
     it('only allows whitelisted keys from object body', () => {
       const result = cdpSchemaTranslator().transform({

--- a/test/unit/logger/winstonFormatters.test.js
+++ b/test/unit/logger/winstonFormatters.test.js
@@ -111,7 +111,7 @@ describe('winstonFormatters', () => {
         tenant: { id: 'tenant-id', message: 'some tenant info' },
         url: {
           full: 'http://localhost/path',
-          path: '/path',
+          path: 'http://localhost/path',
           query: '{"searchFieldType":"SBI","primarySearchPhrase":"107183280"}'
         }
       })
@@ -146,7 +146,7 @@ describe('winstonFormatters', () => {
       },
       url: {
         full: 'http://localhost/path',
-        path: '/path',
+        path: 'http://localhost/path',
         query: '{"searchFieldType":"SBI","primarySearchPhrase":"107183280"}'
       }
     })
@@ -274,6 +274,33 @@ describe('winstonFormatters', () => {
         request: { method: 'GET' }
       })
       expect(result.url).not.toBeDefined()
+    })
+
+    it('uses url as full and path as-is when both are supplied', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: { url: 'https://api.example.com/organisation/123', path: '/organisation/123' }
+      })
+      expect(result.url).toEqual({
+        full: 'https://api.example.com/organisation/123',
+        path: '/organisation/123'
+      })
+    })
+
+    it('sets url.full and url.path when request.url is a full URL string', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: { url: 'https://api.example.com/organisation/123' }
+      })
+      expect(result.url).toEqual({
+        full: 'https://api.example.com/organisation/123',
+        path: '/organisation/123'
+      })
+    })
+
+    it('sets url.full and url.path when request.url is a path-only string', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: { url: '/organisation/123' }
+      })
+      expect(result.url).toEqual({ full: '/organisation/123', path: '/organisation/123' })
     })
   })
 })


### PR DESCRIPTION
Update DAL logging to ensure that context fields are logged to appropriate ECS values.
* Winston formatters updated to
  * extract response code from either `statusCode` or `status` fields
  * use the full request url if available (instead of path) to get the fullest picture of the request
     * support retained for handling just path, or just url  
* Updated BaseRestDataSource to pass the url to the logger
* Updated server.js logging to prepend the path with the serrver path and use that as the url

This fixes Jira ticket: [FCPDAL-109]


[FCPDAL-109]: https://eaflood.atlassian.net/browse/FCPDAL-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ