### PR TITLE
chore: fix tests to match payment schedule actionUnits returned from the mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7528,9 +7528,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -7539,7 +7539,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -13070,6 +13071,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@apollo/datasource-rest": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/acceptance/local-dev-check.test.js
+++ b/test/acceptance/local-dev-check.test.js
@@ -39,7 +39,7 @@ const agreement = [
         parcelName: '6797',
         actionArea: 0.1128,
         actionMTL: null,
-        actionUnits: 66,
+        actionUnits: 66.01,
         parcelTotalArea: 2.3776,
         startDate: '2018-03-07T11:56:24.206Z',
         endDate: '2026-05-10T15:13:55.156Z'
@@ -69,7 +69,7 @@ const agreement = [
         parcelName: '0019',
         actionArea: 0.3114,
         actionMTL: 19,
-        actionUnits: 16,
+        actionUnits: 16.16,
         parcelTotalArea: 1.6253,
         startDate: '2021-04-26T11:46:46.798Z',
         endDate: '2027-04-08T00:15:18.244Z'


### PR DESCRIPTION
The mock now returns floating point numbers for paymentSchedule actionUnits.  This PR updates the acceptance tests to match the new value returned from the mock.

Note - acceptance tests run on gitlab will fail until the upstream mock is merged, then the tests should start to pass