### PR TITLE
fix: prevent didEncounterError crashing on errors with read-only message property

### DIFF
--- a/app/data-sources/BaseRESTDataSource.js
+++ b/app/data-sources/BaseRESTDataSource.js
@@ -25,9 +25,7 @@ export class BaseRESTDataSource extends RESTDataSource {
    * @returns {{ message: string, name?: string, stack?: string }}
    */
   prepareErrorForLogging(error) {
-    if (!error) {
-      return { message: 'unknown/empty error while trying to fetch upstream data' }
-    } else {
+    if (error) {
       let { name, message, stack, cause } = error
       let latestCause = cause
 
@@ -41,6 +39,8 @@ export class BaseRESTDataSource extends RESTDataSource {
         name,
         stack
       }
+    } else {
+      return { message: 'unknown/empty error while trying to fetch upstream data' }
     }
   }
 

--- a/app/data-sources/BaseRESTDataSource.js
+++ b/app/data-sources/BaseRESTDataSource.js
@@ -11,20 +11,44 @@ export class BaseRESTDataSource extends RESTDataSource {
     this.code = code
   }
 
+  /**
+   * Converts an error into a plain object safe for logging.
+   *
+   * Reads `message`, `name`, and `stack` by value rather than assigning to them,
+   * so errors with getter-only `message` properties (e.g. `DOMException` thrown by
+   * `AbortSignal.timeout`) do not cause a `TypeError` in strict mode.
+   *
+   * The full cause chain is appended to `message` in the form:
+   * `"<message> | Caused by <ConstructorName>: <cause.message> | ..."`.
+   *
+   * @param {Error|null} error
+   * @returns {{ message: string, name?: string, stack?: string }}
+   */
+  prepareErrorForLogging(error) {
+    if (!error) {
+      return { message: 'unknown/empty error while trying to fetch upstream data' }
+    } else {
+      let { name, message, stack, cause } = error
+      let latestCause = cause
+
+      while (latestCause) {
+        message += ` | Caused by ${latestCause.constructor.name}: ${latestCause.message}`
+        latestCause = latestCause.cause
+      }
+
+      return {
+        message,
+        name,
+        stack
+      }
+    }
+  }
+
   didEncounterError(error, request, url) {
     request.url = url
-    if (!error) {
-      error = { message: 'unknown/empty error while trying to fetch upstream data' }
-    }
-    let { cause, message } = error
-    while (cause) {
-      message += ` | Caused by ${cause.constructor.name}: ${cause.message}`
-      cause = cause.cause
-    }
-    error.message = message
 
     this.logger.error(`#datasource - ${this.name} - request error`, {
-      error,
+      error: this.prepareErrorForLogging(error),
       request,
       response: { ...error?.extensions?.response },
       code: this.code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@apollo/datasource-rest": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/unit/data-sources/BaseRESTDataSource.test.js
+++ b/test/unit/data-sources/BaseRESTDataSource.test.js
@@ -33,7 +33,7 @@ describe('BaseRESTDataSource', () => {
   })
 
   describe('didEncounterError', () => {
-    test('should set request.path and log error when error occurs', () => {
+    test('should set request.url and log prepared error', () => {
       const mockError = new Error('Test error')
       const mockRequest = { headers: {} }
       const mockUrl = 'https://api.example.com/test'
@@ -44,7 +44,7 @@ describe('BaseRESTDataSource', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(
         '#datasource - Test DataSource - request error',
         expect.objectContaining({
-          error: mockError,
+          error: expect.objectContaining({ message: 'Test error' }),
           request: mockRequest,
           code: 'TEST_001'
         })
@@ -64,7 +64,7 @@ describe('BaseRESTDataSource', () => {
       )
     })
 
-    test('should handle null error and create default error message', () => {
+    test('should handle null error and log default message', () => {
       const mockRequest = { headers: {} }
       const mockUrl = 'https://api.example.com/test'
 
@@ -189,6 +189,63 @@ describe('BaseRESTDataSource', () => {
 
       expect(mockResponse.text).toHaveBeenCalled()
       expect(result).toBe(mockTextData)
+    })
+  })
+
+  describe('prepareErrorForLogging', () => {
+    test('returns default message for null error', () => {
+      const result = dataSource.prepareErrorForLogging(null)
+
+      expect(result).toEqual({ message: 'unknown/empty error while trying to fetch upstream data' })
+    })
+
+    test('returns message, name and stack for an error', () => {
+      const error = new Error('Something went wrong')
+
+      const result = dataSource.prepareErrorForLogging(error)
+
+      expect(result).toEqual({ message: 'Something went wrong', name: 'Error', stack: error.stack })
+    })
+
+    test('appends single cause to message', () => {
+      const error = new Error('Top level error')
+      error.cause = new TypeError('Root cause')
+
+      const result = dataSource.prepareErrorForLogging(error)
+
+      expect(result.message).toBe('Top level error | Caused by TypeError: Root cause')
+    })
+
+    test('walks full cause chain for nested causes', () => {
+      const rootCause = new Error('Root cause')
+      const middleCause = new TypeError('Middle cause')
+      middleCause.cause = rootCause
+      const error = new Error('Top level error')
+      error.cause = middleCause
+
+      const result = dataSource.prepareErrorForLogging(error)
+
+      expect(result.message).toBe(
+        'Top level error | Caused by TypeError: Middle cause | Caused by Error: Root cause'
+      )
+    })
+
+    test('does not throw for DOMException TimeoutError (read-only message property)', () => {
+      // AbortSignal.timeout fires a DOMException whose `message` is getter-only in strict mode.
+      const timeoutError = new DOMException(
+        'The operation was aborted due to timeout',
+        'TimeoutError'
+      )
+
+      expect(() => dataSource.prepareErrorForLogging(timeoutError)).not.toThrow()
+
+      const result = dataSource.prepareErrorForLogging(timeoutError)
+      expect(result).toEqual(
+        expect.objectContaining({
+          message: 'The operation was aborted due to timeout',
+          name: 'TimeoutError'
+        })
+      )
     })
   })
 })

--- a/test/unit/data-sources/rural-payments/rural-payments.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments.test.js
@@ -91,7 +91,7 @@ describe('RuralPayments', () => {
       rp.didEncounterError(error, request, url)
 
       expect(logger.error).toHaveBeenCalledWith('#datasource - Rural payments - request error', {
-        error,
+        error: expect.objectContaining({ message: 'test error' }),
         request,
         response: error.extensions.response,
         code: RURALPAYMENTS_API_REQUEST_001
@@ -112,9 +112,10 @@ describe('RuralPayments', () => {
       rp.didEncounterError(error, request, url)
 
       expect(logger.error).toHaveBeenCalledWith('#datasource - Rural payments - request error', {
-        error: new Error(
-          'test error | Caused by TypeError: intermediate cause | Caused by Error: root cause error'
-        ),
+        error: expect.objectContaining({
+          message:
+            'test error | Caused by TypeError: intermediate cause | Caused by Error: root cause error'
+        }),
         request,
         response: error.extensions.response,
         code: RURALPAYMENTS_API_REQUEST_001


### PR DESCRIPTION
When a timeout occurs (via AbortSignal.timeout), fetch throws a DOMException, which has a getter-only message field.

`didEncounterError` was mutating error.message directly to append the cause chain, causing a TypeError that silently masked the original error — the KITS request error was never logged to the DAL logs - the client received the error `Cannot set property message of  which has only a getter` in the GraphQL errors array.

The fix extracts error preparation into prepareErrorForLogging, which destructures message by value and returns a new plain object, never assigning back to the original error. 

This fixes Jira ticket: [FCPDAL-367]


[FCPDAL-367]: https://eaflood.atlassian.net/browse/FCPDAL-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ