### PR TITLE
fix: ensure that 'event.reference' and 'event.outcome' are correctly published to opensearch for both DAL response log and upstream response log

### DIFF
--- a/app/logger/winstonFormatters.js
+++ b/app/logger/winstonFormatters.js
@@ -113,6 +113,8 @@ export const cdpSchemaTranslator = format((info) => {
   const { error, code, request, response, requestTimeMs, tenant, transactionId, traceId } = info
 
   const parsedUrl = buildUrl(request || {})
+  const httpDetails = buildHttpDetails(request, response, requestTimeMs)
+
   return Object.assign(
     {
       level: info.level,
@@ -122,14 +124,14 @@ export const cdpSchemaTranslator = format((info) => {
       transactionId && { 'transaction.id': transactionId },
       traceId && { 'span.id': traceId, 'trace.id': traceId },
       buildError(error || {}, code),
-      buildHttpDetails(request, response, requestTimeMs),
+      httpDetails,
       buildEvent(
         info.type,
         code,
         request?.method,
         info['@timestamp'],
         requestTimeMs,
-        response?.statusCode,
+        httpDetails.http?.response?.status_code,
         // The URL path is mapped onto the event reference field, which is used in Grafana dashboard queries
         parsedUrl?.url?.path,
         info?.gatewayType

--- a/app/logger/winstonFormatters.js
+++ b/app/logger/winstonFormatters.js
@@ -112,6 +112,7 @@ const buildUrl = ({ body, path, url }) => {
 export const cdpSchemaTranslator = format((info) => {
   const { error, code, request, response, requestTimeMs, tenant, transactionId, traceId } = info
 
+  const parsedUrl = buildUrl(request || {})
   return Object.assign(
     {
       level: info.level,
@@ -129,11 +130,12 @@ export const cdpSchemaTranslator = format((info) => {
         info['@timestamp'],
         requestTimeMs,
         response?.statusCode,
-        request?.path,
+        // The URL path is mapped onto the event reference field, which is used in Grafana dashboard queries
+        parsedUrl?.url?.path,
         info?.gatewayType
       ),
       tenant && { tenant },
-      buildUrl(request || {})
+      parsedUrl
     ]
   )
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@apollo/datasource-rest": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.4.2",
+  "version": "2.4.1",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/unit/logger/winstonFormatters.test.js
+++ b/test/unit/logger/winstonFormatters.test.js
@@ -273,6 +273,23 @@ describe('winstonFormatters', () => {
       })
       expect(result.event.reference).toBe('/organisation/123/details')
     })
+
+    describe('outcome', () => {
+      it('omits event.outcome when no response is provided', () => {
+        const result = cdpSchemaTranslator().transform({ level: 'info', message: 'test' })
+        expect(result.event).not.toBeDefined()
+      })
+
+      it('sets event.outcome from response.status', () => {
+        const result = cdpSchemaTranslator().transform({ response: { status: 404 } })
+        expect(result.event.outcome).toBe('status code: 404')
+      })
+
+      it('sets event.outcome from response.statusCode', () => {
+        const result = cdpSchemaTranslator().transform({ response: { statusCode: 201 } })
+        expect(result.event.outcome).toBe('status code: 201')
+      })
+    })
   })
 
   describe('buildUrl', () => {

--- a/test/unit/logger/winstonFormatters.test.js
+++ b/test/unit/logger/winstonFormatters.test.js
@@ -264,6 +264,17 @@ describe('winstonFormatters', () => {
     })
   })
 
+  describe('buildEvent', () => {
+    it('uses the path portion of a full URL as event.reference', () => {
+      const result = cdpSchemaTranslator().transform({
+        level: 'info',
+        message: 'test',
+        request: { path: 'https://api.example.com/organisation/123/details' }
+      })
+      expect(result.event.reference).toBe('/organisation/123/details')
+    })
+  })
+
   describe('buildUrl', () => {
     it('sets url.full and url.path when request.path is a full URL string', () => {
       const result = cdpSchemaTranslator().transform({


### PR DESCRIPTION

When formatting the log context, url and http details are needed to build the event (`url.path` for `event.reference` and `http.response.status_code` for `event.outcome`), as well as the `http.response.status_code` and `url.pathurl` fields, so build the data first and reuse it in both places.


This fixes [FCPDAL-368]


[FCPDAL-368]: https://eaflood.atlassian.net/browse/FCPDAL-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ