### PR TITLE
FCPDAL-321 validate bank details

### DIFF
--- a/app/data-sources/rural-payments/RuralPaymentsBusiness.js
+++ b/app/data-sources/rural-payments/RuralPaymentsBusiness.js
@@ -209,6 +209,13 @@ export class RuralPaymentsBusiness extends RuralPayments {
     })
   }
 
+  async validateBankChange(submission) {
+    return this.post('bank-change-service/v1/validate', {
+      body: submission,
+      headers: postPutHeaders
+    })
+  }
+
   async getLandUseByBusinessParcel(sbi, sheetId, parcelId, date = new Date()) {
     const response = await this.get(
       `SitiAgriApi/cv/landUseByBusinessParcel/sheet/${sheetId}/parcel/${parcelId}/sbi/${sbi}/list`,

--- a/app/graphql/resolvers/business/mutation.js
+++ b/app/graphql/resolvers/business/mutation.js
@@ -28,23 +28,39 @@ export const Mutation = {
   },
   createBusinessCustomerBankDetails: async (_, { input }, { dataSources }) => {
     const { sbi, crn } = input
-    const organisation = await dataSources.ruralPaymentsBusiness.getOrganisationBySBI(sbi)
+    const { ruralPaymentsBusiness } = dataSources
 
+    const organisation = await ruralPaymentsBusiness.getOrganisationBySBI(sbi)
     if (!organisation.businessReference) {
       throw new NotFound('FRN not found for business')
     }
 
     const personId = await retrievePersonIdByCRN(crn, dataSources)
+    const organisationId = `${organisation.id}`
 
     const submission = transformBankChangeInputToSubmission(input, {
-      organisationId: `${organisation.id}`,
+      organisationId,
       personId: `${personId}`,
       frn: organisation.businessReference
     })
 
-    await dataSources.ruralPaymentsBusiness.submitBankChange(submission)
+    const validation = await ruralPaymentsBusiness.validateBankChange(submission)
+    if (validation.status === 'FAILED') {
+      if (validation.attemptsRemaining === 0) {
+        return {
+          __typename: 'BankDetailsLocked',
+          message: validation.message || 'Bank details failed validation'
+        }
+      }
+      return {
+        __typename: 'BankDetailsValidationFailed',
+        message: validation.message || 'Bank details failed validation',
+        attemptsRemaining: validation.attemptsRemaining
+      }
+    }
 
-    return { success: true }
+    await ruralPaymentsBusiness.submitBankChange(submission)
+    return { __typename: 'BankDetailsSubmitted', success: true }
   },
   updateBusinessName: businessDetailsUpdateResolver,
   updateBusinessPhone: businessDetailsUpdateResolver,

--- a/app/graphql/types/business/mutation/bank-details.gql
+++ b/app/graphql/types/business/mutation/bank-details.gql
@@ -276,24 +276,24 @@ type BankDetailsSubmitted {
   """
   `true` once the bank change submission has been accepted by the upstream service.
   """
-  success: Boolean!
+  success: Boolean! @on
 }
 
 type BankDetailsValidationFailed {
   """
   Detail of the error
   """
-  message: String!
+  message: String! @on
 
   """
   Number of attempts remaining.
   """
-  attemptsRemaining: Int!
+  attemptsRemaining: Int! @on
 }
 
 type BankDetailsLocked {
   """
   Lock message.
   """
-  message: String!
+  message: String! @on
 }

--- a/app/graphql/types/business/mutation/bank-details.gql
+++ b/app/graphql/types/business/mutation/bank-details.gql
@@ -4,7 +4,7 @@ extend type Mutation {
   """
   createBusinessCustomerBankDetails(
     input: CreateBusinessCustomerBankDetailsInput!
-  ): CreateBusinessCustomerBankDetailsResponse @on @auth(requires: [SINGLE_FRONT_DOOR])
+  ): CreateBusinessCustomerBankDetailsResult @on @auth(requires: [SINGLE_FRONT_DOOR])
 }
 
 input CreateBusinessCustomerBankDetailsInput {
@@ -260,9 +260,40 @@ enum BankAccountCurrency {
   EUR
 }
 
-type CreateBusinessCustomerBankDetailsResponse {
+"""
+The outcome of a bank details change request.
+
+- `BankDetailsSubmitted` — The change passed validation and has been submitted.
+- `BankDetailsValidationFailed` — Validation error,
+- `BankDetailsLocked` — The user is locked.
+"""
+union CreateBusinessCustomerBankDetailsResult =
+  | BankDetailsSubmitted
+  | BankDetailsValidationFailed
+  | BankDetailsLocked
+
+type BankDetailsSubmitted {
   """
   `true` once the bank change submission has been accepted by the upstream service.
   """
   success: Boolean!
+}
+
+type BankDetailsValidationFailed {
+  """
+  Detail of the error
+  """
+  message: String!
+
+  """
+  Number of attempts remaining.
+  """
+  attemptsRemaining: Int!
+}
+
+type BankDetailsLocked {
+  """
+  Lock message.
+  """
+  message: String!
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@apollo/datasource-rest": "^6.4.1",
@@ -2435,9 +2435,9 @@
       }
     },
     "node_modules/@hapi/content": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.1.tgz",
-      "integrity": "sha512-lQ2vOoFMNYxwKVnKf+3Pi3PfoviM4EJYlT9JbrBPfEc0xKMiVDqqXF8UTE1S1oKhHQliWSP5t6zTKNlmaXBGcQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.2.tgz",
+      "integrity": "sha512-OKyCOTjNR1hftwSjk9ueyAQTw8AwapvzBrPIWMGn39vhR5PmqLdYFmLc35bsSBye7gSMnlkXfc679bUdMIcRyQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.0"
@@ -2655,9 +2655,9 @@
       }
     },
     "node_modules/@hapi/wreck": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.0.tgz",
-      "integrity": "sha512-0z6ZRCmFEfV/MQqkQomJ7sl/hyxvcZM7LtuVqN3vdAO4vM9eBbowl0kaqQj9EJJQab+3Uuh1GxbGIBFy4NfJ4w==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.2.tgz",
+      "integrity": "sha512-3dMnV2pfhQiyEqu8DL3VBmxkdLiRDiiUDuG79Dp+UK1gL9ZxAfDOUhB6k3D5MLqcgJJ1IARyGFhwoc1NITr/pg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/graphql/full-schema.gql
+++ b/test/graphql/full-schema.gql
@@ -21,7 +21,7 @@ type Mutation {
   updateBusinessVAT(input: UpdateBusinessVATInput!): UpdateBusinessResponse
   createBusinessCustomerBankDetails(
     input: CreateBusinessCustomerBankDetailsInput!
-  ): CreateBusinessCustomerBankDetailsResponse
+  ): CreateBusinessCustomerBankDetailsResult
   # eslint-disable-next-line @graphql-eslint/input-name
   updateBusinessLock(input: UpdateBusinessLockUnlockInput!): UpdateBusinessResponse
   # eslint-disable-next-line @graphql-eslint/input-name
@@ -683,8 +683,22 @@ scalar UkSortCode
 scalar SwiftCode
 scalar IBAN
 
-type CreateBusinessCustomerBankDetailsResponse {
+union CreateBusinessCustomerBankDetailsResult =
+  | BankDetailsSubmitted
+  | BankDetailsValidationFailed
+  | BankDetailsLocked
+
+type BankDetailsSubmitted {
   success: Boolean!
+}
+
+type BankDetailsValidationFailed {
+  message: String!
+  attemptsRemaining: Int!
+}
+
+type BankDetailsLocked {
+  message: String!
 }
 
 type UpdateBusinessResponse {

--- a/test/graphql/mutation/business-bank-details.test.js
+++ b/test/graphql/mutation/business-bank-details.test.js
@@ -1,9 +1,9 @@
 import nock from 'nock'
 import { config } from '../../../app/config.js'
 import { db } from '../../../app/mongo.js'
+import { waitFor } from '../../test-helpers/wait-for.js'
 import { mockOrganisationSearch, mockPersonSearch } from '../helpers.js'
 import { makeTestQuery } from '../makeTestQuery.js'
-import { waitFor } from '../../test-helpers/wait-for.js'
 
 const v1 = nock(config.get('kits.internal.gatewayUrl'))
 
@@ -24,10 +24,29 @@ const input = {
 const query = `
   mutation CreateBusinessCustomerBankDetails($input: CreateBusinessCustomerBankDetailsInput!) {
     createBusinessCustomerBankDetails(input: $input) {
-      success
+      __typename
+      ... on BankDetailsSubmitted {
+        success
+      }
+      ... on BankDetailsValidationFailed {
+        message
+        attemptsRemaining
+      }
+      ... on BankDetailsLocked {
+        message
+      }
     }
   }
 `
+
+const matchValidationResponse = {
+  status: 'MATCH',
+  message: 'All good',
+  attemptsRemaining: 0,
+  account: {
+    bank: { name: 'Acme Bank', sortCode: '123456' }
+  }
+}
 
 const waitForPersonIdToBeCachedInMongo = async () => {
   await waitFor(async () => {
@@ -54,6 +73,8 @@ describe('createBusinessCustomerBankDetails', () => {
   })
 
   test('submits the bank change to the upstream service', async () => {
+    v1.post('/bank-change-service/v1/validate').reply(200, matchValidationResponse)
+
     let submittedBody
     v1.post('/bank-change-service/v1/submit', (body) => {
       submittedBody = body
@@ -65,12 +86,9 @@ describe('createBusinessCustomerBankDetails', () => {
     await waitForPersonIdToBeCachedInMongo()
 
     expect(nock.isDone()).toBe(true)
-    expect(result).toEqual({
-      data: {
-        createBusinessCustomerBankDetails: {
-          success: true
-        }
-      }
+    expect(result.data.createBusinessCustomerBankDetails).toEqual({
+      __typename: 'BankDetailsSubmitted',
+      success: true
     })
 
     expect(submittedBody).toEqual({
@@ -90,6 +108,67 @@ describe('createBusinessCustomerBankDetails', () => {
         }
       },
       country: { currency: 'GBP' }
+    })
+  })
+
+  test('submits when validation returns PARTIAL_MATCH', async () => {
+    v1.post('/bank-change-service/v1/validate').reply(200, {
+      status: 'PARTIAL_MATCH',
+      message: 'Some details did not match — please confirm',
+      attemptsRemaining: 0,
+      account: { bank: { name: 'Acme Bank', sortCode: '123456' } }
+    })
+    v1.post('/bank-change-service/v1/submit').reply(200, {})
+
+    const result = await makeTestQuery(query, null, true, { input }, [], false)
+
+    await waitForPersonIdToBeCachedInMongo()
+
+    expect(nock.isDone()).toBe(true)
+    expect(result.data.createBusinessCustomerBankDetails).toEqual({
+      __typename: 'BankDetailsSubmitted',
+      success: true
+    })
+  })
+
+  test('returns BankDetailsValidationFailed', async () => {
+    v1.post('/bank-change-service/v1/validate').reply(200, {
+      status: 'FAILED',
+      message: "Details don't match",
+      attemptsRemaining: 2,
+      account: { bank: { sortCode: '123456' } }
+    })
+
+    const result = await makeTestQuery(query, null, true, { input }, [], false)
+
+    await waitForPersonIdToBeCachedInMongo()
+
+    expect(nock.isDone()).toBe(true)
+    expect(result.errors).toBeUndefined()
+    expect(result.data.createBusinessCustomerBankDetails).toEqual({
+      __typename: 'BankDetailsValidationFailed',
+      message: "Details don't match",
+      attemptsRemaining: 2
+    })
+  })
+
+  test('returns BankDetailsLocked', async () => {
+    v1.post('/bank-change-service/v1/validate').reply(200, {
+      status: 'FAILED',
+      message: "Details don't match",
+      attemptsRemaining: 0,
+      account: { bank: { sortCode: '123456' } }
+    })
+
+    const result = await makeTestQuery(query, null, true, { input }, [], false)
+
+    await waitForPersonIdToBeCachedInMongo()
+
+    expect(nock.isDone()).toBe(true)
+    expect(result.errors).toBeUndefined()
+    expect(result.data.createBusinessCustomerBankDetails).toEqual({
+      __typename: 'BankDetailsLocked',
+      message: "Details don't match"
     })
   })
 

--- a/test/graphql/partial-schema.gql
+++ b/test/graphql/partial-schema.gql
@@ -4,6 +4,12 @@ type Query {
   permissionGroups: [PermissionGroup]
 }
 
+type Mutation {
+  createBusinessCustomerBankDetails(
+    input: CreateBusinessCustomerBankDetailsInput!
+  ): CreateBusinessCustomerBankDetailsResult
+}
+
 type Phone {
   mobile: String
   landline: String
@@ -42,6 +48,12 @@ type EntityStatus {
 }
 
 scalar Date
+
+scalar UkAccountNumber
+
+scalar UkSortCode
+
+scalar SwiftCode
 
 type Agreement {
   contractId: ID
@@ -324,3 +336,102 @@ type PermissionGroup {
   id: PermissionGroupId!
   name: String!
 }
+
+input CreateBusinessCustomerBankDetailsInput {
+  sbi: ID!
+  crn: ID!
+  account: BankAccountInput!
+}
+
+input BankAccountInput @oneOf {
+  ukBusiness: UkBusinessBankAccountInput
+  ukPersonal: UkPersonalBankAccountInput
+  ukBusinessBuildingSociety: UkBusinessBuildingSocietyBankAccountInput
+  ukPersonalBuildingSociety: UkPersonalBuildingSocietyBankAccountInput
+  euBusiness: EuBusinessBankAccountInput
+  euPersonal: EuPersonalBankAccountInput
+}
+
+input UkBusinessBankAccountInput {
+  accountHolderName: String!
+  accountNumber: UkAccountNumber!
+  bankName: String!
+  sortCode: UkSortCode!
+  currency: BankAccountCurrency!
+}
+
+input UkPersonalBankAccountInput {
+  forename: String!
+  surname: String!
+  accountNumber: UkAccountNumber!
+  bankName: String!
+  sortCode: UkSortCode!
+  currency: BankAccountCurrency!
+}
+
+input UkBusinessBuildingSocietyBankAccountInput {
+  accountHolderName: String!
+  accountNumber: UkAccountNumber!
+  rollNumber: String
+  bankName: String!
+  sortCode: UkSortCode!
+  currency: BankAccountCurrency!
+}
+
+input UkPersonalBuildingSocietyBankAccountInput {
+  forename: String!
+  surname: String!
+  accountNumber: UkAccountNumber!
+  rollNumber: String
+  bankName: String!
+  sortCode: UkSortCode!
+  currency: BankAccountCurrency!
+}
+
+input EuBusinessBankAccountInput {
+  accountHolderName: String!
+  accountNumber: String!
+  iban: IBAN!
+  countryCode: String!
+  bankName: String!
+  sortCode: String!
+  swiftCode: SwiftCode
+  currency: BankAccountCurrency!
+}
+
+input EuPersonalBankAccountInput {
+  forename: String!
+  surname: String!
+  accountNumber: String!
+  iban: IBAN!
+  countryCode: String!
+  bankName: String!
+  sortCode: String!
+  swiftCode: SwiftCode
+  currency: BankAccountCurrency!
+}
+
+enum BankAccountCurrency {
+  GBP
+  EUR
+}
+
+union CreateBusinessCustomerBankDetailsResult =
+  | BankDetailsSubmitted
+  | BankDetailsValidationFailed
+  | BankDetailsLocked
+
+type BankDetailsSubmitted {
+  success: Boolean!
+}
+
+type BankDetailsValidationFailed {
+  message: String!
+  attemptsRemaining: Int!
+}
+
+type BankDetailsLocked {
+  message: String!
+}
+
+scalar IBAN

--- a/test/unit/data-sources/rural-payments/rural-payments-business.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments-business.test.js
@@ -513,4 +513,35 @@ describe('Rural Payments Business', () => {
       expect(result).toEqual({})
     })
   })
+
+  describe('validateBankChange', () => {
+    test('posts the submission to the validate endpoint', async () => {
+      const validateResponse = {
+        status: 'MATCH',
+        message: 'All good',
+        attemptsRemaining: 0,
+        account: { bank: { name: 'Acme Bank', sortCode: '123456' } }
+      }
+      httpPost.mockResolvedValueOnce(validateResponse)
+
+      const submission = {
+        organisationId: '5583781',
+        sbi: '110405990',
+        account: {
+          accountType: 'UK_BUSINESS',
+          name: 'John Doe',
+          number: '14345678',
+          bank: { name: 'Acme Bank', sortCode: '123456' }
+        }
+      }
+
+      const result = await ruralPaymentsBusiness.validateBankChange(submission)
+
+      expect(httpPost).toHaveBeenCalledWith('bank-change-service/v1/validate', {
+        body: submission,
+        headers: expect.any(Object)
+      })
+      expect(result).toEqual(validateResponse)
+    })
+  })
 })

--- a/test/unit/resolvers/business/business-mutation.test.js
+++ b/test/unit/resolvers/business/business-mutation.test.js
@@ -375,21 +375,26 @@ describe('Business Mutation createBusinessCustomerBankDetails', () => {
   }
 
   beforeEach(() => {
+    mockCustomerCommonModule.retrievePersonIdByCRN.mockReset()
     dataSources = {
       ruralPaymentsBusiness: {
-        getOrganisationBySBI: jest.fn(),
+        getOrganisationBySBI: jest.fn().mockResolvedValue({
+          id: 5583781,
+          businessReference: '10014489653'
+        }),
+        validateBankChange: jest.fn().mockResolvedValue({
+          status: 'MATCH',
+          message: 'All good',
+          attemptsRemaining: 0,
+          account: { bank: { name: 'Acme Bank', sortCode: '123456' } }
+        }),
         submitBankChange: jest.fn().mockResolvedValue({})
       }
     }
+    mockCustomerCommonModule.retrievePersonIdByCRN.mockResolvedValue(5020949)
   })
 
-  it('submits the bank change with ids resolved from sbi and crn', async () => {
-    dataSources.ruralPaymentsBusiness.getOrganisationBySBI.mockResolvedValue({
-      id: 5583781,
-      businessReference: '10014489653'
-    })
-    mockCustomerCommonModule.retrievePersonIdByCRN.mockResolvedValue(5020949)
-
+  it('validates then submits the bank change', async () => {
     const response = await Mutation.createBusinessCustomerBankDetails(
       {},
       { input: baseInput },
@@ -397,28 +402,37 @@ describe('Business Mutation createBusinessCustomerBankDetails', () => {
     )
 
     expect(dataSources.ruralPaymentsBusiness.getOrganisationBySBI).toHaveBeenCalledWith('110405990')
-    expect(mockCustomerCommonModule.retrievePersonIdByCRN).toHaveBeenCalledWith(
-      '1100209492',
-      dataSources
-    )
-    expect(dataSources.ruralPaymentsBusiness.submitBankChange).toHaveBeenCalledWith(
+    expect(dataSources.ruralPaymentsBusiness.validateBankChange).toHaveBeenCalledWith(
       expect.objectContaining({
         organisationId: '5583781',
         personId: '5020949',
         sbi: '110405990',
         frn: '10014489653',
-        crn: '1100209492',
-        account: expect.objectContaining({
-          accountType: 'UK_BUSINESS',
-          name: 'Acme Farms Ltd',
-          number: '14345678',
-          bank: expect.objectContaining({ name: 'Acme Bank', sortCode: '123456' })
-        }),
-        country: expect.objectContaining({ currency: 'GBP' }),
-        submissionDateTime: expect.stringMatching(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+        crn: '1100209492'
       })
     )
-    expect(response).toEqual({ success: true })
+    expect(dataSources.ruralPaymentsBusiness.submitBankChange).toHaveBeenCalledWith(
+      dataSources.ruralPaymentsBusiness.validateBankChange.mock.calls[0][0]
+    )
+    expect(response).toEqual({ __typename: 'BankDetailsSubmitted', success: true })
+  })
+
+  it('submits when validation returns PARTIAL_MATCH', async () => {
+    dataSources.ruralPaymentsBusiness.validateBankChange.mockResolvedValue({
+      status: 'PARTIAL_MATCH',
+      message: 'Some details did not match',
+      attemptsRemaining: 0,
+      account: { bank: { name: 'Acme Bank' } }
+    })
+
+    const response = await Mutation.createBusinessCustomerBankDetails(
+      {},
+      { input: baseInput },
+      { dataSources }
+    )
+
+    expect(dataSources.ruralPaymentsBusiness.submitBankChange).toHaveBeenCalled()
+    expect(response).toEqual({ __typename: 'BankDetailsSubmitted', success: true })
   })
 
   it('throws NotFound when the organisation has no FRN', async () => {
@@ -434,32 +448,65 @@ describe('Business Mutation createBusinessCustomerBankDetails', () => {
     expect(dataSources.ruralPaymentsBusiness.submitBankChange).not.toHaveBeenCalled()
   })
 
-  it('propagates the data source error when the organisation lookup fails', async () => {
-    dataSources.ruralPaymentsBusiness.getOrganisationBySBI.mockRejectedValue(
-      new Error('Rural payments organisation not found')
+  it('returns BankDetailsValidationFailed ', async () => {
+    dataSources.ruralPaymentsBusiness.validateBankChange.mockResolvedValue({
+      status: 'FAILED',
+      message: "Details don't match",
+      attemptsRemaining: 2,
+      account: { bank: { sortCode: '123456' } }
+    })
+
+    const response = await Mutation.createBusinessCustomerBankDetails(
+      {},
+      { input: baseInput },
+      { dataSources }
     )
 
-    await expect(
-      Mutation.createBusinessCustomerBankDetails({}, { input: baseInput }, { dataSources })
-    ).rejects.toThrow('Rural payments organisation not found')
-
-    expect(mockCustomerCommonModule.retrievePersonIdByCRN).not.toHaveBeenCalled()
+    expect(response).toEqual({
+      __typename: 'BankDetailsValidationFailed',
+      message: "Details don't match",
+      attemptsRemaining: 2
+    })
     expect(dataSources.ruralPaymentsBusiness.submitBankChange).not.toHaveBeenCalled()
   })
 
-  it('propagates the data source error when the personId lookup fails', async () => {
-    dataSources.ruralPaymentsBusiness.getOrganisationBySBI.mockResolvedValue({
-      id: 5583781,
-      businessReference: '10014489653'
+  it('falls back to a default message', async () => {
+    dataSources.ruralPaymentsBusiness.validateBankChange.mockResolvedValue({
+      status: 'FAILED',
+      attemptsRemaining: 1
     })
-    mockCustomerCommonModule.retrievePersonIdByCRN.mockRejectedValue(
-      new Error('Rural payments customer not found')
+
+    const response = await Mutation.createBusinessCustomerBankDetails(
+      {},
+      { input: baseInput },
+      { dataSources }
     )
 
-    await expect(
-      Mutation.createBusinessCustomerBankDetails({}, { input: baseInput }, { dataSources })
-    ).rejects.toThrow('Rural payments customer not found')
+    expect(response).toEqual({
+      __typename: 'BankDetailsValidationFailed',
+      message: 'Bank details failed validation',
+      attemptsRemaining: 1
+    })
+  })
 
+  it('returns BankDetailsLocked', async () => {
+    dataSources.ruralPaymentsBusiness.validateBankChange.mockResolvedValue({
+      status: 'FAILED',
+      message: "Details don't match",
+      attemptsRemaining: 0,
+      account: { bank: { sortCode: '123456' } }
+    })
+
+    const response = await Mutation.createBusinessCustomerBankDetails(
+      {},
+      { input: baseInput },
+      { dataSources }
+    )
+
+    expect(response).toEqual({
+      __typename: 'BankDetailsLocked',
+      message: "Details don't match"
+    })
     expect(dataSources.ruralPaymentsBusiness.submitBankChange).not.toHaveBeenCalled()
   })
 })

--- a/test/unit/resolvers/business/business-mutation.test.js
+++ b/test/unit/resolvers/business/business-mutation.test.js
@@ -509,6 +509,25 @@ describe('Business Mutation createBusinessCustomerBankDetails', () => {
     })
     expect(dataSources.ruralPaymentsBusiness.submitBankChange).not.toHaveBeenCalled()
   })
+
+  it('returns BankDetailsLocked with default message when none provided', async () => {
+    dataSources.ruralPaymentsBusiness.validateBankChange.mockResolvedValue({
+      status: 'FAILED',
+      attemptsRemaining: 0
+    })
+
+    const response = await Mutation.createBusinessCustomerBankDetails(
+      {},
+      { input: baseInput },
+      { dataSources }
+    )
+
+    expect(response).toEqual({
+      __typename: 'BankDetailsLocked',
+      message: 'Bank details failed validation'
+    })
+    expect(dataSources.ruralPaymentsBusiness.submitBankChange).not.toHaveBeenCalled()
+  })
 })
 
 describe('Business Mutation updateBusinessLockStatus', () => {


### PR DESCRIPTION
Add validation to update/create bank details.

Example request:
```
  mutation CreateBusinessCustomerBankDetails($input: CreateBusinessCustomerBankDetailsInput!) {
    createBusinessCustomerBankDetails(input: $input) {
      ... on BankDetailsSubmitted {
        success
      }
      ... on BankDetailsValidationFailed {
        message
        attemptsRemaining
      }
      ... on BankDetailsLocked {
        message
      }
    }
  }
```

Variables:
```
  {
    "input": {
      "sbi": {{sbi}},
      "crn": {{crn}},
      "account": {
        "ukBusiness": {
          "accountHolderName": "Acme Farms Ltd",
          "accountNumber": "11111100",
          "bankName": "Match Bank",
          "sortCode": "111111",
          "currency": "GBP"
        }
      }
    }
  }
```

This fixes/resolves/relates to Jira ticket: [FCPDAL-321]


[FCPDAL-321]: https://eaflood.atlassian.net/browse/FCPDAL-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ