### PR TITLE
update payments on hold code function

### DIFF
--- a/app/graphql/types/business/payments.gql
+++ b/app/graphql/types/business/payments.gql
@@ -18,7 +18,8 @@ type Payment {
 }
 
 type PaymentLineItem {
-  agreementClaimNo: String!
+  agreementNumber: String!
+  claimReferenceNumber: String!
   scheme: String!
   marketingYear: String!
   description: String!

--- a/app/transformers/hitachi/payments.js
+++ b/app/transformers/hitachi/payments.js
@@ -3,7 +3,7 @@ function calculateOnHoldStatus(holdCodes) {
     return false
   }
 
-  if (holdCodes.includes('NTHLD')) {
+  if (holdCodes.includes('NTHLD') && holdCodes.length === 1) {
     return false
   }
 

--- a/app/transformers/hitachi/payments.js
+++ b/app/transformers/hitachi/payments.js
@@ -22,7 +22,8 @@ function transformPayment(payment) {
 
 function transformLineItem(lineItem) {
   return {
-    agreementClaimNo: `${lineItem.parmAgreementNumber}/${lineItem.parmClaimRefNumber}`,
+    agreementNumber: lineItem.parmAgreementNumber,
+    claimReferenceNumber: lineItem.parmClaimRefNumber,
     scheme: lineItem.parmScheme,
     marketingYear: lineItem.parmMarketingYear,
     description: lineItem.parmDescription,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@apollo/datasource-rest": "^6.4.1",
@@ -11322,9 +11322,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/graphql/full-schema.gql
+++ b/test/graphql/full-schema.gql
@@ -334,7 +334,8 @@ type Payment {
 }
 
 type PaymentLineItem {
-  agreementClaimNo: String!
+  agreementNumber: String!
+  claimReferenceNumber: String!
   scheme: String!
   marketingYear: String!
   description: String!

--- a/test/unit/transformers/hitachi/payments.test.js
+++ b/test/unit/transformers/hitachi/payments.test.js
@@ -62,7 +62,8 @@ describe('transformBusinessPayments', () => {
           currency: 'GBP',
           lineItems: [
             {
-              agreementClaimNo: 'AGR456/CLAIM002',
+              agreementNumber: 'AGR456',
+              claimReferenceNumber: 'CLAIM002',
               scheme: 'SFI',
               marketingYear: '2023',
               description: 'Sustainable Farming Incentive',
@@ -77,7 +78,8 @@ describe('transformBusinessPayments', () => {
           currency: 'GBP',
           lineItems: [
             {
-              agreementClaimNo: 'AGR123/CLAIM001',
+              agreementNumber: 'AGR123',
+              claimReferenceNumber: 'CLAIM001',
               scheme: 'BPS',
               marketingYear: '2023',
               description: 'Basic Payment Scheme',
@@ -200,7 +202,9 @@ describe('transformBusinessPayments', () => {
 
     const result = transformBusinessPayments(hitachiResponse)
     expect(result.payments[0].lineItems).toHaveLength(2)
-    expect(result.payments[0].lineItems[0].agreementClaimNo).toBe('AGR123/CLAIM001')
-    expect(result.payments[0].lineItems[1].agreementClaimNo).toBe('AGR123/CLAIM002')
+    expect(result.payments[0].lineItems[0].agreementNumber).toBe('AGR123')
+    expect(result.payments[0].lineItems[0].claimReferenceNumber).toBe('CLAIM001')
+    expect(result.payments[0].lineItems[1].agreementNumber).toBe('AGR123')
+    expect(result.payments[0].lineItems[1].claimReferenceNumber).toBe('CLAIM002')
   })
 })

--- a/test/unit/transformers/hitachi/payments.test.js
+++ b/test/unit/transformers/hitachi/payments.test.js
@@ -94,7 +94,7 @@ describe('transformBusinessPayments', () => {
       { holdCodes: [], expected: false },
       { holdCodes: ['NTHLD'], expected: false },
       { holdCodes: ['HOLD1'], expected: true },
-      { holdCodes: ['NTHLD', 'HOLD1'], expected: false },
+      { holdCodes: ['NTHLD', 'HOLD1'], expected: true },
       { holdCodes: ['HOLD1', 'HOLD2'], expected: true }
     ]
 


### PR DESCRIPTION
Some times an account might look like this:

```
"parmHoldCodes": [
      "NTHLD",
      "PROBATE"
    ],
 ```

Says that "not on hold" (`NTHLD`) while at the same time having an on-hold code (`PROBATE`) 🤦‍♂️. This handles that; an account is only "not on hold" when `NTHLD` is the _only_ item in the array.

I also separated out the two fields that had been combined. They are combine in CV Frontend but that's a presentation-decision, not something that should be done here in the DAL.

This fixes/resolves/relates to Jira ticket: [FCPDAL-372]


[FCPDAL-372]: https://eaflood.atlassian.net/browse/FCPDAL-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ