### PR TITLE
chore: Refactor mongo out to own module in preparation for addition of more healthchecks

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -5,9 +5,10 @@ import { secureContext } from '@defra/hapi-secure-context'
 
 import { context } from './graphql/context.js'
 import { apolloServer } from './graphql/server.js'
-import { DAL_UNHANDLED_ERROR_001, MONGO_DB_ERROR_001 } from './logger/codes.js'
+import { DAL_UNHANDLED_ERROR_001 } from './logger/codes.js'
 import { logger } from './logger/logger.js'
 import { mongoClient } from './mongo.js'
+import { runHealthChecks } from './utils/health/index.js'
 import { server } from './server.js'
 
 const init = async () => {
@@ -25,13 +26,8 @@ const init = async () => {
   ])
 
   mongoClient.secureContext = tls.createSecureContext()
-  try {
-    await mongoClient.connect() // Test mongo connection
-    logger.info('Connected to MongoDB')
-  } catch (err) {
-    logger.error('#DAL - Error connecting to MongoDB', { error: err, code: MONGO_DB_ERROR_001 })
-    process.exit(1)
-  }
+
+  await runHealthChecks()
 
   await server.start()
 

--- a/app/utils/health/index.js
+++ b/app/utils/health/index.js
@@ -1,0 +1,14 @@
+import { healthCheck as mongo } from './mongo.js'
+
+const healthChecks = [mongo]
+
+/**
+ * Runs all registered health checks.
+ *
+ * If a check fails, then it should log the failure at error-level and terminate the process
+ */
+export const runHealthChecks = async () => {
+  for (const healthCheck of healthChecks) {
+    await healthCheck()
+  }
+}

--- a/app/utils/health/index.js
+++ b/app/utils/health/index.js
@@ -1,4 +1,5 @@
 import { healthCheck as mongo } from './mongo.js'
+import { logger } from '../../logger/logger.js'
 
 const healthChecks = [mongo]
 
@@ -8,7 +9,10 @@ const healthChecks = [mongo]
  * If a check fails, then it should log the failure at error-level and terminate the process
  */
 export const runHealthChecks = async () => {
-  for (const healthCheck of healthChecks) {
-    await healthCheck()
+  try {
+    await Promise.all(healthChecks.map((check) => check()))
+  } catch (err) {
+    logger.error('#DAL - unrecoverable healthcheck error, shutting down...', err)
+    process.exit(1)
   }
 }

--- a/app/utils/health/mongo.js
+++ b/app/utils/health/mongo.js
@@ -1,0 +1,13 @@
+import { MONGO_DB_ERROR_001 } from '../../logger/codes.js'
+import { logger } from '../../logger/logger.js'
+import { mongoClient } from '../../mongo.js'
+
+export const healthCheck = async () => {
+  try {
+    await mongoClient.connect()
+    logger.info('Connected to MongoDB')
+  } catch (err) {
+    logger.error('#DAL - Error connecting to MongoDB', { error: err, code: MONGO_DB_ERROR_001 })
+    process.exit(1)
+  }
+}

--- a/app/utils/health/mongo.js
+++ b/app/utils/health/mongo.js
@@ -8,6 +8,6 @@ export const healthCheck = async () => {
     logger.info('Connected to MongoDB')
   } catch (err) {
     logger.error('#DAL - Error connecting to MongoDB', { error: err, code: MONGO_DB_ERROR_001 })
-    process.exit(1)
+    throw err
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.8.2",
+      "version": "2.8.3",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/unit/app/index.test.js
+++ b/test/unit/app/index.test.js
@@ -11,7 +11,12 @@ const mockLogger = {
   }
 }
 
+const mockRunHealthChecks = jest.fn()
+
 jest.unstable_mockModule('../../../app/logger/logger.js', () => mockLogger)
+jest.unstable_mockModule('../../../app/utils/health/index.js', () => ({
+  runHealthChecks: mockRunHealthChecks
+}))
 
 const { server } = await import('../../../app/server.js')
 
@@ -21,8 +26,8 @@ describe('App initialization', () => {
     jest.spyOn(server, 'register').mockResolvedValue()
     jest.spyOn(server, 'start').mockResolvedValue()
     jest.spyOn(server, 'stop').mockResolvedValue()
-    jest.spyOn(mongoClient, 'connect').mockResolvedValue()
     jest.spyOn(mongoClient, 'close').mockResolvedValue()
+    mockRunHealthChecks.mockResolvedValue()
     jest.spyOn(process, 'exit').mockReturnValue(1)
 
     server.info = { uri: 'http://localhost:3000' }
@@ -52,31 +57,11 @@ describe('App initialization', () => {
       }
     ])
 
-    // Verify MongoDB connection was attempted
-    expect(mongoClient.connect).toHaveBeenCalled()
+    // Verify that health checks were run
+    expect(mockRunHealthChecks).toHaveBeenCalled()
 
     // Verify server was started
     expect(server.start).toHaveBeenCalled()
-  })
-
-  it('should abort immediately if MongoDB fails to connect', async () => {
-    const mockError = new Error('MongoDB connection failed')
-    mongoClient.connect.mockRejectedValueOnce(mockError)
-
-    // Import the app after mocks are set up
-    await import('../../../app/index.js?call=2')
-
-    // Verify MongoDB connection was attempted
-    expect(mongoClient.connect).toHaveBeenCalled()
-
-    // Verify process exit was called due to failure
-    expect(process.exit).toHaveBeenCalledWith(1)
-
-    // Verify error was logged
-    expect(mockLogger.logger.error).toHaveBeenCalledWith('#DAL - Error connecting to MongoDB', {
-      error: mockError,
-      code: expect.any(String)
-    })
   })
 
   it('should handle unhandled rejections', async () => {

--- a/test/unit/utils/health/index.test.js
+++ b/test/unit/utils/health/index.test.js
@@ -10,7 +10,8 @@ const { runHealthChecks } = await import('../../../../app/utils/health/index.js'
 
 describe('runHealthChecks', () => {
   beforeEach(() => {
-    mockMongoHealthCheck.mockResolvedValue()
+    mockMongoHealthCheck.mockResolvedValue(undefined)
+    jest.spyOn(process, 'exit').mockReturnValue(1)
   })
 
   afterEach(() => {
@@ -23,10 +24,12 @@ describe('runHealthChecks', () => {
     expect(mockMongoHealthCheck).toHaveBeenCalledTimes(1)
   })
 
-  it('should stop and propagate error on first failing health check', async () => {
+  it('should stop and terminate process if any mongo health check fails', async () => {
     const error = new Error('Health check failed')
     mockMongoHealthCheck.mockRejectedValueOnce(error)
 
-    await expect(runHealthChecks()).rejects.toThrow(error)
+    await runHealthChecks()
+
+    expect(process.exit).toHaveBeenCalledWith(1)
   })
 })

--- a/test/unit/utils/health/index.test.js
+++ b/test/unit/utils/health/index.test.js
@@ -1,0 +1,32 @@
+import { expect, jest } from '@jest/globals'
+
+const mockMongoHealthCheck = jest.fn()
+
+jest.unstable_mockModule('../../../../app/utils/health/mongo.js', () => ({
+  healthCheck: mockMongoHealthCheck
+}))
+
+const { runHealthChecks } = await import('../../../../app/utils/health/index.js')
+
+describe('runHealthChecks', () => {
+  beforeEach(() => {
+    mockMongoHealthCheck.mockResolvedValue()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should run all registered health checks', async () => {
+    await runHealthChecks()
+
+    expect(mockMongoHealthCheck).toHaveBeenCalledTimes(1)
+  })
+
+  it('should stop and propagate error on first failing health check', async () => {
+    const error = new Error('Health check failed')
+    mockMongoHealthCheck.mockRejectedValueOnce(error)
+
+    await expect(runHealthChecks()).rejects.toThrow(error)
+  })
+})

--- a/test/unit/utils/health/mongo.test.js
+++ b/test/unit/utils/health/mongo.test.js
@@ -1,0 +1,44 @@
+import { expect, jest } from '@jest/globals'
+import { mongoClient } from '../../../../app/mongo.js'
+
+const mockLogger = {
+  logger: {
+    error: jest.fn(),
+    info: jest.fn()
+  }
+}
+
+jest.unstable_mockModule('../../../../app/logger/logger.js', () => mockLogger)
+
+const { healthCheck } = await import('../../../../app/utils/health/mongo.js')
+
+describe('Mongo health check', () => {
+  beforeEach(() => {
+    jest.spyOn(mongoClient, 'connect').mockResolvedValue()
+    jest.spyOn(process, 'exit').mockReturnValue(1)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should log success when MongoDB connects', async () => {
+    await healthCheck()
+
+    expect(mongoClient.connect).toHaveBeenCalled()
+    expect(mockLogger.logger.info).toHaveBeenCalledWith('Connected to MongoDB')
+  })
+
+  it('should log error and exit when MongoDB fails to connect', async () => {
+    const mockError = new Error('MongoDB connection failed')
+    mongoClient.connect.mockRejectedValueOnce(mockError)
+
+    await healthCheck()
+
+    expect(mockLogger.logger.error).toHaveBeenCalledWith('#DAL - Error connecting to MongoDB', {
+      error: mockError,
+      code: expect.any(String)
+    })
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+})

--- a/test/unit/utils/health/mongo.test.js
+++ b/test/unit/utils/health/mongo.test.js
@@ -15,7 +15,6 @@ const { healthCheck } = await import('../../../../app/utils/health/mongo.js')
 describe('Mongo health check', () => {
   beforeEach(() => {
     jest.spyOn(mongoClient, 'connect').mockResolvedValue()
-    jest.spyOn(process, 'exit').mockReturnValue(1)
   })
 
   afterEach(() => {
@@ -29,16 +28,15 @@ describe('Mongo health check', () => {
     expect(mockLogger.logger.info).toHaveBeenCalledWith('Connected to MongoDB')
   })
 
-  it('should log error and exit when MongoDB fails to connect', async () => {
+  it('should log error and throw when MongoDB fails to connect', async () => {
     const mockError = new Error('MongoDB connection failed')
     mongoClient.connect.mockRejectedValueOnce(mockError)
 
-    await healthCheck()
+    await expect(healthCheck()).rejects.toThrow('MongoDB connection failed')
 
     expect(mockLogger.logger.error).toHaveBeenCalledWith('#DAL - Error connecting to MongoDB', {
       error: mockError,
       code: expect.any(String)
     })
-    expect(process.exit).toHaveBeenCalledWith(1)
   })
 })


### PR DESCRIPTION
Establish pattern for future health checks.
index.js now delegates to `runAllHealthChecks`

`runAllHealthChecks` simply imports all available healthchecks (currently on mongo) and evaluates each healthcheck, failing fast

This relates to Jira ticket: [FCPDAL-217]


[FCPDAL-217]: https://eaflood.atlassian.net/browse/FCPDAL-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ