### PR TITLE
feat: remove internalGatewayDevOverrideEmail

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -158,13 +158,6 @@ export const config = convict({
         format: String,
         default: null,
         env: 'KITS_INTERNAL_GATEWAY_URL'
-      },
-      devOverrideEmail: {
-        doc: 'Dev email address to send in the `email` header',
-        format: String,
-        env: 'KITS_INT_DEV_OVERRIDE_EMAIL',
-        nullable: true,
-        default: null
       }
     },
     external: {

--- a/app/data-sources/rural-payments/RuralPayments.js
+++ b/app/data-sources/rural-payments/RuralPayments.js
@@ -21,7 +21,7 @@ export function extractCrnFromDefraIdToken(token) {
 export class RuralPayments extends BaseRESTDataSource {
   // Note this gets overridden by the customFetch
   request = null
-  constructor(config, { request, gatewayType, internalGatewayDevOverrideEmail }) {
+  constructor(config, { request, gatewayType }) {
     super(config, { name: 'Rural payments', code: RURALPAYMENTS_API_REQUEST_001 })
     this.request = request
 
@@ -32,7 +32,6 @@ export class RuralPayments extends BaseRESTDataSource {
       )
     }
 
-    this.internalGatewayDevOverrideEmail = internalGatewayDevOverrideEmail
     this.baseURL = this.gatewayType === 'external' ? externalGatewayUrl : internalGatewayUrl
 
     if (appConfig.get('kits.disableMTLS')) {
@@ -67,9 +66,7 @@ export class RuralPayments extends BaseRESTDataSource {
     const headers = this.request.headers
     const additionalHeaders = {}
 
-    if (this.gatewayType === 'internal' && this.internalGatewayDevOverrideEmail) {
-      additionalHeaders.email = this.internalGatewayDevOverrideEmail
-    } else if (this.gatewayType === 'internal' && headers.email) {
+    if (this.gatewayType === 'internal' && headers.email) {
       additionalHeaders.email = headers.email
     } else if (this.gatewayType === 'external' && headers['x-forwarded-authorization']) {
       additionalHeaders.Authorization = headers['x-forwarded-authorization']

--- a/app/graphql/context.js
+++ b/app/graphql/context.js
@@ -1,6 +1,5 @@
 import jwt from 'jsonwebtoken'
 import { getAuth, getRequestingGroup } from '../auth/authenticate.js'
-import { config } from '../config.js'
 import { HitachiPayments } from '../data-sources/hitachi/HitachiPayments.js'
 import { MongoBusiness } from '../data-sources/mongo/Business.js'
 import { MongoCustomer } from '../data-sources/mongo/Customer.js'
@@ -11,8 +10,6 @@ import { Permissions } from '../data-sources/static/permissions.js'
 import { BadRequest } from '../errors/graphql.js'
 import { logger } from '../logger/logger.js'
 import { db } from '../mongo.js'
-
-const internalGatewayDevOverrideEmail = config.get('kits.internal.devOverrideEmail')
 
 export const extractOrgIdFromDefraIdToken = (sbi, token) => {
   const { payload } = jwt.decode(token, { complete: true })
@@ -42,8 +39,7 @@ export async function context({ request }) {
     { logger: requestLogger },
     {
       request,
-      gatewayType: request.headers['gateway-type'] || 'internal',
-      internalGatewayDevOverrideEmail
+      gatewayType: request.headers['gateway-type'] || 'internal'
     }
   ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.10.3",
+      "version": "2.11.0",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.10.3",
+  "version": "2.11.0",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/unit/data-sources/rural-payments/rural-payments-custom-fetch.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments-custom-fetch.test.js
@@ -74,13 +74,11 @@ describe('RuralPayments Custom Fetch', () => {
     const request = {}
     const rp = new RuralPayments(config, {
       request,
-      gatewayType: 'internal',
-      internalGatewayDevOverrideEmail: 'override-email'
+      gatewayType: 'internal'
     })
 
     expect(rp.request).toBe(request)
     expect(rp.gatewayType).toBe('internal')
-    expect(rp.internalGatewayDevOverrideEmail).toBe('override-email')
     expect(rp.baseURL).toBe(fakeInternalURL)
     const requestTls = {
       host: 'rp_kits_gateway_internal_url',
@@ -118,13 +116,11 @@ describe('RuralPayments Custom Fetch', () => {
     const request = {}
     const rp = new RuralPayments(config, {
       request,
-      gatewayType: 'external',
-      internalGatewayDevOverrideEmail: 'override-email'
+      gatewayType: 'external'
     })
 
     expect(rp.request).toBe(request)
     expect(rp.gatewayType).toBe('external')
-    expect(rp.internalGatewayDevOverrideEmail).toBe('override-email')
     expect(rp.baseURL).toBe(fakeExternalURL)
     const requestTls = {
       host: 'rp_kits_gateway_internal_url',
@@ -163,13 +159,11 @@ describe('RuralPayments Custom Fetch', () => {
     const request = {}
     const rp = new RuralPayments(config, {
       request,
-      gatewayType: 'internal',
-      internalGatewayDevOverrideEmail: 'override-email'
+      gatewayType: 'internal'
     })
 
     expect(rp.request).toBe(request)
     expect(rp.gatewayType).toBe('internal')
-    expect(rp.internalGatewayDevOverrideEmail).toBe('override-email')
     expect(rp.baseURL).toBe(fakeInternalURL)
 
     // check that the fetch works as expected with timeout, but without mTLS
@@ -196,13 +190,11 @@ describe('RuralPayments Custom Fetch', () => {
     const request = {}
     const rp = new RuralPayments(config, {
       request,
-      gatewayType: 'external',
-      internalGatewayDevOverrideEmail: 'override-email'
+      gatewayType: 'external'
     })
 
     expect(rp.request).toBe(request)
     expect(rp.gatewayType).toBe('external')
-    expect(rp.internalGatewayDevOverrideEmail).toBe('override-email')
     expect(rp.baseURL).toBe(fakeExternalURL)
 
     // check that the fetch works as expected with timeout, but without mTLS

--- a/test/unit/data-sources/rural-payments/rural-payments.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments.test.js
@@ -267,23 +267,6 @@ describe('RuralPayments', () => {
 
       expect(rp.willSendRequest(path, request)).resolves.toBeUndefined()
     })
-
-    test('does not throw if gateway type is internal and internalGatewayDevOverrideEmail is present', () => {
-      const rp = new RuralPayments(
-        { logger },
-        {
-          gatewayType: 'internal',
-          request: {
-            headers: {}
-          },
-          internalGatewayDevOverrideEmail: 'test'
-        }
-      )
-      const request = {}
-      const path = 'test-path'
-
-      expect(rp.willSendRequest(path, request)).resolves.toBeUndefined()
-    })
   })
 
   describe('trace', () => {


### PR DESCRIPTION
Remove the override email on the internal gateway.

[CV frontend now sends the override email](https://github.com/DEFRA/fcp-cv-frontend/pull/91) when required and DAL always requires an email header. It essentially undoes #121 as the front end is better able to handle this now we've moved away from Power Apps.

This fixes/resolves/relates to Jira ticket: [FCPDAL-422]


[FCPDAL-422]: https://eaflood.atlassian.net/browse/FCPDAL-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ