### PR TITLE
chore: fix node version on pull request build to fix node-fetch issue…

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup npm
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 24.18
           cache: npm
 
       - name: Install and audit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/acceptance/customer/mutations.test.js
+++ b/test/acceptance/customer/mutations.test.js
@@ -106,9 +106,9 @@ const generateInputsForCRN = (crn) => ({
       line4: 'acceptance-line4',
       line5: 'acceptance-line5',
       pafOrganisationName: 'acceptance-pafOrganisationName',
-      postalCode: 'acceptance-postalCode',
+      postalCode: 'SW1A 2AA',
       street: 'acceptance-street',
-      uprn: 'acceptance-uprn'
+      uprn: '123456789012'
     }
   },
   dateOfBirthInput: {
@@ -122,7 +122,7 @@ const generateInputsForCRN = (crn) => ({
   emailInput: {
     crn,
     email: {
-      address: 'acceptance-email-address'
+      address: 'acceptance@example.com'
     }
   },
   nameInput: {
@@ -132,8 +132,8 @@ const generateInputsForCRN = (crn) => ({
   phoneInput: {
     crn,
     phone: {
-      landline: 'acceptance-landline',
-      mobile: 'acceptance-mobile'
+      landline: '01234 567890',
+      mobile: '07700 900000'
     }
   }
 })
@@ -195,7 +195,7 @@ const fullMutation = gql`
   }
 `
 const nameFullInput = {
-  title: 'acceptance-title-full',
+  title: 'acceptance-title-xxx',
   otherTitle: 'acceptance-otherTitle-full',
   first: 'acceptance-first-full',
   middle: 'acceptance-middle-full',
@@ -219,19 +219,19 @@ const generateFullInputForCRN = (crn) => ({
       line4: 'acceptance-line4-full',
       line5: 'acceptance-line5-full',
       pafOrganisationName: 'acceptance-pafOrganisationName-full',
-      postalCode: 'acceptance-postalCode-full',
+      postalCode: 'SW1A 2AB',
       street: 'acceptance-street-full',
-      uprn: 'acceptance-uprn-full'
+      uprn: '210987654321'
     },
     dateOfBirth: '2000-03-01', // must be a valid date string
     doNotContact: false, // must be boolean
     email: {
-      address: 'acceptance-email-address-full'
+      address: 'acceptance-full@example.com'
     },
     ...nameFullInput,
     phone: {
-      landline: 'acceptance-landline-full',
-      mobile: 'acceptance-mobile-full'
+      landline: '01234 567891',
+      mobile: '07700 900001'
     }
   }
 })

--- a/test/acceptance/search/queries.test.js
+++ b/test/acceptance/search/queries.test.js
@@ -159,7 +159,7 @@ describe('Business Search Queries', () => {
       ],
       pageInfo: {
         number: 0,
-        size: 20,
+        size: 100,
         totalPages: 1,
         totalElements: 1
       }
@@ -228,7 +228,7 @@ describe('Customer Search Queries', () => {
       ],
       pageInfo: {
         number: 0,
-        size: 20,
+        size: 100,
         totalPages: 1,
         totalElements: 1
       }


### PR DESCRIPTION
Three elements to the PR

1) Node version.   Version 24.17.0 introduced an issue with node-fetch that prevented the code coverage action used by the pull request github runner from completing.  This issue was resolved in version 24.18.0

2) The upstream mock had recent changes to the schema that needed to be reflected in the acceptance tests (schema is now stricter)

3) The page size used to be hardcoded (to 20) in the mock response, but is now dynamic based on what was requested (default from the DAL side is 100)
