### PR TITLE
chore/kits healthcheck on startup

### DIFF
--- a/app/data-sources/rural-payments/RuralPayments.js
+++ b/app/data-sources/rural-payments/RuralPayments.js
@@ -64,6 +64,13 @@ export class RuralPayments extends BaseRESTDataSource {
 
   async addAuthentication(request) {
     const headers = this.request.headers
+
+    if (headers.healthcheck) {
+      // Health check calls intentionally carry no user credentials. Sending the request
+      // unauthenticated still proves the upstream is reachable, typically via a 403 response.
+      return
+    }
+
     const additionalHeaders = {}
 
     if (this.gatewayType === 'internal' && headers.email) {

--- a/app/data-sources/rural-payments/RuralPaymentsReference.js
+++ b/app/data-sources/rural-payments/RuralPaymentsReference.js
@@ -1,0 +1,9 @@
+import { RuralPayments } from './RuralPayments.js'
+
+// TODO This is a placeholder until ref data is delivered
+export class RuralPaymentsReference extends RuralPayments {
+  async legalStatus() {
+    const response = await this.get(`reference/legalstatus`)
+    return response._data
+  }
+}

--- a/app/data-sources/rural-payments/RuralPaymentsReference.js
+++ b/app/data-sources/rural-payments/RuralPaymentsReference.js
@@ -1,9 +1,0 @@
-import { RuralPayments } from './RuralPayments.js'
-
-// TODO This is a placeholder until ref data is delivered
-export class RuralPaymentsReference extends RuralPayments {
-  async legalStatus() {
-    const response = await this.get(`reference/legalstatus`)
-    return response._data
-  }
-}

--- a/app/utils/health/index.js
+++ b/app/utils/health/index.js
@@ -1,7 +1,8 @@
 import { healthCheck as mongo } from './mongo.js'
+import { healthCheck as ruralPayments } from './rural-payments.js'
 import { logger } from '../../logger/logger.js'
 
-const healthChecks = [mongo]
+const healthChecks = [mongo, ruralPayments]
 
 /**
  * Runs all registered health checks.

--- a/app/utils/health/rural-payments.js
+++ b/app/utils/health/rural-payments.js
@@ -1,0 +1,21 @@
+import { RURALPAYMENTS_API_ERROR_001 } from '../../logger/codes.js'
+import { logger } from '../../logger/logger.js'
+import { config } from '../../config.js'
+import { RuralPaymentsReference } from '../../data-sources/rural-payments/RuralPaymentsReference.js'
+
+export const healthCheck = async () => {
+  try {
+    const ruralPaymentsReference = new RuralPaymentsReference(
+      { logger },
+      { headers: { email: config.get('healthCheck.ruralPaymentsPortalEmail') } }
+    )
+    await ruralPaymentsReference.legalStatus()
+    logger.info('Connected to rural payments')
+  } catch (err) {
+    logger.error('#DAL - Error connecting to rural payments', {
+      error: err,
+      code: RURALPAYMENTS_API_ERROR_001
+    })
+    throw err
+  }
+}

--- a/app/utils/health/rural-payments.js
+++ b/app/utils/health/rural-payments.js
@@ -1,21 +1,50 @@
+import { StatusCodes } from 'http-status-codes'
 import { RURALPAYMENTS_API_ERROR_001 } from '../../logger/codes.js'
 import { logger } from '../../logger/logger.js'
-import { config } from '../../config.js'
-import { RuralPaymentsReference } from '../../data-sources/rural-payments/RuralPaymentsReference.js'
+import { RuralPaymentsReferenceData } from '../../data-sources/rural-payments/RuralPaymentsReferenceData.js'
 
-export const healthCheck = async () => {
+const runRuralPaymentsCheck = async (type) => {
   try {
-    const ruralPaymentsReference = new RuralPaymentsReference(
+    // Rural payment requests must be initiated by a real user, so health check calls will never have the necessary
+    // credentials to successfully invoke an endpoint (when auth is turned on).  The goal of the health check is to
+    // verify that the upstream is available and serving responses.   A forbidden response is still a response, so
+    // the goal of the health check is a 200 when auth is disabled, or a 403 when auth is enabled.  Given this, no
+    // authentication headers will be set and the 'healthcheck' header will instruct the datasource to submit the
+    // request, even without authorisation.
+    const ruralPaymentsReferenceData = new RuralPaymentsReferenceData(
       { logger },
-      { headers: { email: config.get('healthCheck.ruralPaymentsPortalEmail') } }
+      {
+        gatewayType: type,
+        request: {
+          headers: {
+            healthcheck: true
+          }
+        }
+      }
     )
-    await ruralPaymentsReference.legalStatus()
-    logger.info('Connected to rural payments')
+    await ruralPaymentsReferenceData.getReferenceData('legalstatus')
+
+    // Success case when auth is not enabled
+    logger.info(`SUCCESS: HTTP connection to ${type} Rural Payments upstream succeeded`)
   } catch (err) {
-    logger.error('#DAL - Error connecting to rural payments', {
+    if (err?.extensions?.http?.status === StatusCodes.FORBIDDEN) {
+      // A 403 still means the upstream responded - it just doesn't recognise the caller.
+      logger.info(
+        `SUCCESS: HTTP connection to ${type} Rural Payments upstream succeeded (received expected 403 Forbidden)`
+      )
+      return
+    }
+
+    // Any other error is unexpected, so fail the health check
+    logger.error(`#DAL - Error connecting to ${type} Rural Payments upstream`, {
       error: err,
       code: RURALPAYMENTS_API_ERROR_001
     })
     throw err
   }
+}
+
+/** Check that both internal and external Rural Payments endpoints are available */
+export const healthCheck = async () => {
+  await Promise.all([runRuralPaymentsCheck('internal'), runRuralPaymentsCheck('external')])
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/unit/data-sources/rural-payments/rural-payments.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments.test.js
@@ -267,6 +267,25 @@ describe('RuralPayments', () => {
 
       expect(rp.willSendRequest(path, request)).resolves.toBeUndefined()
     })
+
+    test('does not throw and sends the request unauthenticated when the healthcheck header is present', async () => {
+      const rp = new RuralPayments(
+        { logger },
+        {
+          gatewayType: 'internal',
+          request: {
+            headers: {
+              healthcheck: true
+            }
+          }
+        }
+      )
+      const request = { headers: {} }
+      const path = 'test-path'
+
+      await expect(rp.willSendRequest(path, request)).resolves.toBeUndefined()
+      expect(request.headers).toEqual({})
+    })
   })
 
   describe('trace', () => {

--- a/test/unit/logger/logger.test.js
+++ b/test/unit/logger/logger.test.js
@@ -1,6 +1,11 @@
 import { jest } from '@jest/globals'
 import ConsoleTransportInstance from 'winston-transport'
+import { v4 as uuidv4 } from 'uuid'
 import { config } from '../../../app/config.js'
+
+const loadFreshLogger = async () => {
+  return await import(`../../../app/logger/logger.js?version=${uuidv4()}`)
+}
 
 describe('logger', () => {
   let configMockPath
@@ -20,25 +25,25 @@ describe('logger', () => {
   })
 
   it('Single default log transport enabled', async () => {
-    const { logger } = await import(`../../../app/logger/logger.js?version=${Date.now()}`)
+    const { logger } = await loadFreshLogger()
     expect(logger.transports.length).toEqual(1)
     expect(logger.transports[0]).toBeInstanceOf(ConsoleTransportInstance)
   })
 
   it('should use ecsFormat in production environment', async () => {
     configMockPath.nodeEnv = 'production'
-    const { logger } = await import(`../../../app/logger/logger.js?version=${Date.now()}`)
+    const { logger } = await loadFreshLogger()
     expect(logger.transports[0].format).toBeDefined()
   })
 
   it('should set the log level based on LOG_LEVEL environment variable', async () => {
     configMockPath.logLevel = 'debug'
-    const { logger } = await import(`../../../app/logger/logger.js?version=${Date.now()}`)
+    const { logger } = await loadFreshLogger()
     expect(logger.level).toEqual('debug')
   })
 
   it('should close transports on process exit', async () => {
-    const { logger } = await import(`../../../app/logger/logger.js?version=${Date.now()}`)
+    const { logger } = await loadFreshLogger()
     logger.transports[0].close = jest.fn()
     process.emit('exit')
     expect(logger.transports[0].close).toHaveBeenCalled()

--- a/test/unit/utils/health/index.test.js
+++ b/test/unit/utils/health/index.test.js
@@ -1,9 +1,14 @@
 import { expect, jest } from '@jest/globals'
 
 const mockMongoHealthCheck = jest.fn()
+const mockRuralPaymentsHealthCheck = jest.fn()
 
 jest.unstable_mockModule('../../../../app/utils/health/mongo.js', () => ({
   healthCheck: mockMongoHealthCheck
+}))
+
+jest.unstable_mockModule('../../../../app/utils/health/rural-payments.js', () => ({
+  healthCheck: mockRuralPaymentsHealthCheck
 }))
 
 const { runHealthChecks } = await import('../../../../app/utils/health/index.js')
@@ -11,6 +16,7 @@ const { runHealthChecks } = await import('../../../../app/utils/health/index.js'
 describe('runHealthChecks', () => {
   beforeEach(() => {
     mockMongoHealthCheck.mockResolvedValue(undefined)
+    mockRuralPaymentsHealthCheck.mockResolvedValue(undefined)
     jest.spyOn(process, 'exit').mockReturnValue(1)
   })
 
@@ -22,11 +28,21 @@ describe('runHealthChecks', () => {
     await runHealthChecks()
 
     expect(mockMongoHealthCheck).toHaveBeenCalledTimes(1)
+    expect(mockRuralPaymentsHealthCheck).toHaveBeenCalledTimes(1)
   })
 
-  it('should stop and terminate process if any mongo health check fails', async () => {
+  it('should stop and terminate process if the mongo health check fails', async () => {
     const error = new Error('Health check failed')
     mockMongoHealthCheck.mockRejectedValueOnce(error)
+
+    await runHealthChecks()
+
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('should stop and terminate process if the rural payments health check fails', async () => {
+    const error = new Error('Health check failed')
+    mockRuralPaymentsHealthCheck.mockRejectedValueOnce(error)
 
     await runHealthChecks()
 

--- a/test/unit/utils/health/rural-payments.test.js
+++ b/test/unit/utils/health/rural-payments.test.js
@@ -7,49 +7,97 @@ const mockLogger = {
   }
 }
 
-const RuralPaymentsReferenceMock = jest.fn()
-const legalStatusMock = jest.fn()
-RuralPaymentsReferenceMock.prototype.legalStatus = legalStatusMock
+const RuralPaymentsReferenceDataMock = jest.fn()
+const getReferenceDataMock = jest.fn()
 
 jest.unstable_mockModule('../../../../app/logger/logger.js', () => mockLogger)
 
 jest.unstable_mockModule(
-  '../../../../app/data-sources/rural-payments/RuralPaymentsReference.js',
-  () => ({ RuralPaymentsReference: RuralPaymentsReferenceMock })
+  '../../../../app/data-sources/rural-payments/RuralPaymentsReferenceData.js',
+  () => ({ RuralPaymentsReferenceData: RuralPaymentsReferenceDataMock })
 )
-
-jest.unstable_mockModule('../../../../app/config.js', () => ({
-  config: {
-    get: jest.fn().mockReturnValue('test@example.com')
-  }
-}))
 
 const { healthCheck } = await import('../../../../app/utils/health/rural-payments.js')
 
 describe('Rural payments health check', () => {
   beforeEach(() => {
-    legalStatusMock.mockResolvedValue()
+    RuralPaymentsReferenceDataMock.mockImplementation(() => ({
+      getReferenceData: getReferenceDataMock
+    }))
+    getReferenceDataMock.mockResolvedValue()
   })
 
   afterEach(() => {
     jest.clearAllMocks()
   })
 
-  it('should log success when rural payments connects', async () => {
+  it('should log success when rural payments connects for both internal and external gateways', async () => {
     await healthCheck()
 
-    expect(legalStatusMock).toHaveBeenCalled()
-    expect(mockLogger.logger.info).toHaveBeenCalledWith('Connected to rural payments')
+    expect(getReferenceDataMock).toHaveBeenCalledTimes(2)
+    expect(RuralPaymentsReferenceDataMock).toHaveBeenCalledWith(
+      { logger: mockLogger.logger },
+      {
+        gatewayType: 'internal',
+        request: { headers: { healthcheck: true } }
+      }
+    )
+    expect(RuralPaymentsReferenceDataMock).toHaveBeenCalledWith(
+      { logger: mockLogger.logger },
+      {
+        gatewayType: 'external',
+        request: { headers: { healthcheck: true } }
+      }
+    )
+    expect(mockLogger.logger.info).toHaveBeenCalledWith(
+      'SUCCESS: HTTP connection to internal Rural Payments upstream succeeded'
+    )
+    expect(mockLogger.logger.info).toHaveBeenCalledWith(
+      'SUCCESS: HTTP connection to external Rural Payments upstream succeeded'
+    )
+    expect(mockLogger.logger.info).toHaveBeenCalledTimes(2)
   })
 
-  it('should log error and throw when rural payments fails to connect', async () => {
+  it('should log success, and not throw, when upstream responds with a 403 Forbidden', async () => {
+    const forbiddenError = Object.assign(new Error('Forbidden'), {
+      extensions: { http: { status: 403 } }
+    })
+    getReferenceDataMock.mockRejectedValue(forbiddenError)
+
+    await expect(healthCheck()).resolves.toBeUndefined()
+
+    expect(mockLogger.logger.error).not.toHaveBeenCalled()
+    expect(mockLogger.logger.info).toHaveBeenCalledWith(
+      'SUCCESS: HTTP connection to internal Rural Payments upstream succeeded (received expected 403 Forbidden)'
+    )
+    expect(mockLogger.logger.info).toHaveBeenCalledWith(
+      'SUCCESS: HTTP connection to external Rural Payments upstream succeeded (received expected 403 Forbidden)'
+    )
+  })
+
+  it('should log error and throw when the internal gateway fails to connect', async () => {
     const mockError = new Error('Rural payments connection failed')
-    legalStatusMock.mockRejectedValueOnce(mockError)
+    getReferenceDataMock.mockRejectedValueOnce(mockError)
 
     await expect(healthCheck()).rejects.toThrow('Rural payments connection failed')
 
     expect(mockLogger.logger.error).toHaveBeenCalledWith(
-      '#DAL - Error connecting to rural payments',
+      '#DAL - Error connecting to internal Rural Payments upstream',
+      {
+        error: mockError,
+        code: expect.any(String)
+      }
+    )
+  })
+
+  it('should log error and throw when only the external gateway fails to connect', async () => {
+    const mockError = new Error('Rural payments connection failed')
+    getReferenceDataMock.mockResolvedValueOnce().mockRejectedValueOnce(mockError)
+
+    await expect(healthCheck()).rejects.toThrow('Rural payments connection failed')
+
+    expect(mockLogger.logger.error).toHaveBeenCalledWith(
+      '#DAL - Error connecting to external Rural Payments upstream',
       {
         error: mockError,
         code: expect.any(String)

--- a/test/unit/utils/health/rural-payments.test.js
+++ b/test/unit/utils/health/rural-payments.test.js
@@ -1,0 +1,59 @@
+import { expect, jest } from '@jest/globals'
+
+const mockLogger = {
+  logger: {
+    error: jest.fn(),
+    info: jest.fn()
+  }
+}
+
+const RuralPaymentsReferenceMock = jest.fn()
+const legalStatusMock = jest.fn()
+RuralPaymentsReferenceMock.prototype.legalStatus = legalStatusMock
+
+jest.unstable_mockModule('../../../../app/logger/logger.js', () => mockLogger)
+
+jest.unstable_mockModule(
+  '../../../../app/data-sources/rural-payments/RuralPaymentsReference.js',
+  () => ({ RuralPaymentsReference: RuralPaymentsReferenceMock })
+)
+
+jest.unstable_mockModule('../../../../app/config.js', () => ({
+  config: {
+    get: jest.fn().mockReturnValue('test@example.com')
+  }
+}))
+
+const { healthCheck } = await import('../../../../app/utils/health/rural-payments.js')
+
+describe('Rural payments health check', () => {
+  beforeEach(() => {
+    legalStatusMock.mockResolvedValue()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should log success when rural payments connects', async () => {
+    await healthCheck()
+
+    expect(legalStatusMock).toHaveBeenCalled()
+    expect(mockLogger.logger.info).toHaveBeenCalledWith('Connected to rural payments')
+  })
+
+  it('should log error and throw when rural payments fails to connect', async () => {
+    const mockError = new Error('Rural payments connection failed')
+    legalStatusMock.mockRejectedValueOnce(mockError)
+
+    await expect(healthCheck()).rejects.toThrow('Rural payments connection failed')
+
+    expect(mockLogger.logger.error).toHaveBeenCalledWith(
+      '#DAL - Error connecting to rural payments',
+      {
+        error: mockError,
+        code: expect.any(String)
+      }
+    )
+  })
+})


### PR DESCRIPTION
Internal and external route startup health checks for RuralPayments/KITS.

Note that back-end initiated calls to the rural payments endpoints will never fully succeed, as they need to be associated with a "real" user account.   This means that we have no authentication headers to send, so when auth is turned on, the upstream calls will always respond with 403.

The health check makes no attempt to mimic the required headers.  Instead, we pass a 'healthcheck' flag into the request and the  Datasource bypasses the auth header validation checks, leaving the upstream to reject the calls.

Unrelated fix: Logger test fails intermittently as the cache-busting import's version was not granular enough.  Changed from millisecond precision Date, to use uuid (following same pattern used in config.test.js) 

This resolves Jira ticket: [FCPDAL-217]


[FCPDAL-217]: https://eaflood.atlassian.net/browse/FCPDAL-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ