### PR TITLE
Chore/version fix

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Full history including all tags, needed to find the highest existing version tag
           fetch-depth: 0
 
       - name: Setup npm
@@ -41,11 +42,12 @@ jobs:
 
       - name: Verify semantic version bump
         run: |
-          TARGET_BRANCH_VERSION=$(git show origin/${{ github.base_ref }}:package.json | jq -r '.version')
+          # Use the highest existing repo-wide tag rather than main's package.json version, since hotfix branches can tag a version higher than the latest main version
+          TARGET_VERSION=$(git tag -l | xargs npx -y semver | tail -n1)
           PR_BRANCH_VERSION=$(jq -r '.version' package.json)
 
-          if ! npx -y semver -r ">${TARGET_BRANCH_VERSION}" "${PR_BRANCH_VERSION}" > /dev/null  ; then
-            echo "ERROR: Branch package.json version (${PR_BRANCH_VERSION}) must be semantically greater than target branch (${TARGET_BRANCH_VERSION})"
+          if ! npx -y semver -r ">${TARGET_VERSION}" "${PR_BRANCH_VERSION}" > /dev/null  ; then
+            echo "ERROR: Branch package.json version (${PR_BRANCH_VERSION}) must be semantically greater than the highest existing repository tag (${TARGET_VERSION})"
             exit 1
           fi
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,16 +1,17 @@
 #!/bin/sh
-git fetch origin main --quiet
+git fetch --tags --quiet
 
 if ! command -v jq > /dev/null 2>&1; then
   echo "ERROR: jq is required but not installed (so that package json version bump can be verified). See https://jqlang.org/download/"
   exit 1
 fi
 
-REMOTE_VERSION=$(git show origin/main:package.json | jq -r '.version')
+# Use the highest existing repo-wide tag rather than main's package.json, since hotfix branches can tag a version higher than the latest main version
+TARGET_VERSION=$(git tag -l | xargs npx -y semver | tail -n1)
 LOCAL_VERSION=$(jq -r '.version' ./package.json)
 
-if ! npx -y semver -r ">${REMOTE_VERSION}" "${LOCAL_VERSION}" > /dev/null 2>&1 ; then
-  echo "ERROR: Branch package.json version (${LOCAL_VERSION}) must be semantically greater than target branch (${REMOTE_VERSION})"
+if ! npx -y semver -r ">${TARGET_VERSION}" "${LOCAL_VERSION}" > /dev/null 2>&1 ; then
+  echo "ERROR: Branch package.json version (${LOCAL_VERSION}) must be semantically greater than the highest existing repository tag (${TARGET_VERSION})"
   exit 1
 fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.15.3",
+  "version": "2.15.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.15.3",
+      "version": "2.15.4",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.15.3",
+  "version": "2.15.4",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",


### PR DESCRIPTION
Bump version to unblock main build

Going forwards, uses git tags (which provide a more complete repository-wide picture) to ensure that the local/PR version is semantically greater than the highest tag.




