### PR TITLE
Feat/dal external to internal service account

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -32,6 +32,7 @@ KITS_INTERNAL_GATEWAY_URL=https://rp_kits_gateway_internal_url/
 # Kits Gateway for RP (Locally generated self-signed cert and key for testing)
 KITS_EXTERNAL_GATEWAY_URL=https://rp_kits_gateway_external_url/
 KIT_EXT_PERSON_ID_OVERRIDE=3337243
+KITS_DAL_SERVICE_ACCOUNT_EMAIL=service-account@example.com
 
 MONGO_DATABASE='fcp-dal-api'
 

--- a/app/config.js
+++ b/app/config.js
@@ -215,6 +215,12 @@ export const config = convict({
       format: 'int',
       default: 100,
       env: 'KITS_REQUEST_PAGE_SIZE'
+    },
+    dalServiceAccountEmail: {
+      doc: 'Email identifying the DAL service account.',
+      format: String,
+      default: null,
+      env: 'KITS_DAL_SERVICE_ACCOUNT_EMAIL'
     }
   },
   hitachi: {

--- a/app/data-sources/BaseRESTDataSource.js
+++ b/app/data-sources/BaseRESTDataSource.js
@@ -5,10 +5,11 @@ import { HttpError } from '../errors/graphql.js'
 import { sendMetric } from '../logger/sendMetric.js'
 
 export class BaseRESTDataSource extends RESTDataSource {
-  constructor(config, { name, code }) {
+  constructor(config, { name, code, gatewayType }) {
     super(config)
     this.name = name
     this.code = code
+    this.gatewayType = gatewayType
   }
 
   /**
@@ -108,6 +109,7 @@ export class BaseRESTDataSource extends RESTDataSource {
     this.logger.info(`#datasource - ${this.name} - response`, {
       type: 'http',
       code: this.code,
+      gatewayType: this.gatewayType,
       requestTimeMs,
       request: {
         id: request.id,

--- a/app/data-sources/rural-payments/RuralPayments.js
+++ b/app/data-sources/rural-payments/RuralPayments.js
@@ -21,12 +21,16 @@ export function extractCrnFromDefraIdToken(token) {
 export class RuralPayments extends BaseRESTDataSource {
   // Note this gets overridden by the customFetch
   request = null
-  constructor(config, { request, gatewayType }) {
-    super(config, { name: 'Rural payments', code: RURALPAYMENTS_API_REQUEST_001 })
+  constructor(config, { request, gatewayType = 'internal' }) {
+    super(config, {
+      name: 'Rural payments',
+      code: RURALPAYMENTS_API_REQUEST_001,
+      action: gatewayType
+    })
     this.request = request
 
-    this.gatewayType = gatewayType || 'internal'
-    if (!['internal', 'external'].includes(this.gatewayType)) {
+    this.gatewayType = gatewayType
+    if (!['internal', 'external', 'service-account'].includes(this.gatewayType)) {
       throw new BadRequest(
         `gateway-type header must be one of internal or external received: ${gatewayType}`
       )
@@ -73,7 +77,10 @@ export class RuralPayments extends BaseRESTDataSource {
 
     const additionalHeaders = {}
 
-    if (this.gatewayType === 'internal' && headers.email) {
+    if (
+      (this.gatewayType === 'internal' || this.gatewayType === 'service-account') &&
+      headers.email
+    ) {
       additionalHeaders.email = headers.email
     } else if (this.gatewayType === 'external' && headers['x-forwarded-authorization']) {
       additionalHeaders.Authorization = headers['x-forwarded-authorization']

--- a/app/data-sources/rural-payments/RuralPayments.js
+++ b/app/data-sources/rural-payments/RuralPayments.js
@@ -21,22 +21,13 @@ export function extractCrnFromDefraIdToken(token) {
 export class RuralPayments extends BaseRESTDataSource {
   // Note this gets overridden by the customFetch
   request = null
-  constructor(config, { request, gatewayType = 'internal' }) {
+  constructor(config, { request }) {
     super(config, {
       name: 'Rural payments',
-      code: RURALPAYMENTS_API_REQUEST_001,
-      action: gatewayType
+      code: RURALPAYMENTS_API_REQUEST_001
     })
-    this.request = request
 
-    this.gatewayType = gatewayType
-    if (!['internal', 'external', 'service-account'].includes(this.gatewayType)) {
-      throw new BadRequest(
-        `gateway-type header must be one of internal or external received: ${gatewayType}`
-      )
-    }
-
-    this.baseURL = this.gatewayType === 'external' ? externalGatewayUrl : internalGatewayUrl
+    this.initialiseRequest(request)
 
     if (appConfig.get('kits.disableMTLS')) {
       this.httpCache.httpFetch = (url, options = {}) =>
@@ -53,9 +44,8 @@ export class RuralPayments extends BaseRESTDataSource {
         port: kitsURL.port,
         servername: kitsURL.hostname
       }
-      requestTls.secureContext = tls.createSecureContext(
-        this.gatewayType === 'external' ? appConfig.externalMTLS : appConfig.internalMTLS
-      )
+      requestTls.secureContext = this.createSecureContext()
+
       this.httpCache.httpFetch = (url, options = {}) =>
         // use undici fetch which supports mTLS & env proxy via agent
         fetch11(url, {
@@ -77,26 +67,68 @@ export class RuralPayments extends BaseRESTDataSource {
 
     const additionalHeaders = {}
 
-    if (
-      (this.gatewayType === 'internal' || this.gatewayType === 'service-account') &&
-      headers.email
-    ) {
-      additionalHeaders.email = headers.email
-    } else if (this.gatewayType === 'external' && headers['x-forwarded-authorization']) {
+    const internalEmail = this.authContext.internalAuthHeader || this.authContext.serviceAccount
+
+    if (internalEmail) {
+      additionalHeaders.email = internalEmail
+    } else {
       additionalHeaders.Authorization = headers['x-forwarded-authorization']
       additionalHeaders.crn = extractCrnFromDefraIdToken(headers['x-forwarded-authorization'])
-    } else {
-      throw new HttpError(StatusCodes.UNPROCESSABLE_ENTITY, {
-        extensions: {
-          message:
-            'Invalid request headers, must be either "email: {valid user email}" or "X-Forwarded-Authorization: {defra-id token}" & "gateway-type: external" headers'
-        }
-      })
     }
 
     request.headers = {
       ...request.headers,
       ...additionalHeaders
     }
+  }
+
+  isExternalRoute() {
+    return this.gatewayRoute === 'external'
+  }
+
+  getBaseURL() {
+    return this.isExternalRoute() ? externalGatewayUrl : internalGatewayUrl
+  }
+
+  createSecureContext() {
+    return tls.createSecureContext(
+      this.isExternalRoute() ? appConfig.externalMTLS : appConfig.internalMTLS
+    )
+  }
+
+  initialiseRequest(request) {
+    this.request = request
+    this.authContext = {
+      internalAuthHeader: this.request.headers.email,
+      externalAuthHeader: this.request.headers['x-forwarded-authorization'],
+      serviceAccount: this.request.headers['service-account']
+    }
+
+    if (this.authContext.internalAuthHeader) {
+      this.gatewayRoute = 'internal'
+      this.authType = 'internal'
+    } else if (this.authContext.serviceAccount && this.authContext.externalAuthHeader) {
+      // Service account supplied alongside the caller's own external auth header - this is an
+      // otherwise-external request that the DAL service account is taking over routing for.
+      this.gatewayRoute = 'internal'
+      this.authType = 'dal-service-account'
+    } else if (this.authContext.serviceAccount) {
+      // Consumer has supplied a service account email vis the service-account header
+      this.gatewayRoute = 'internal'
+      this.authType = 'client-service-account'
+    } else if (this.authContext.externalAuthHeader) {
+      this.gatewayRoute = 'external'
+      this.authType = 'external'
+    } else {
+      throw new HttpError(StatusCodes.UNPROCESSABLE_ENTITY, {
+        extensions: {
+          message:
+            'Invalid request headers, must be either "email: {valid user email}", "email: {valid service account email}" or "X-Forwarded-Authorization: {defra-id token}" & "gateway-type: external" headers'
+        }
+      })
+    }
+
+    this.gatewayType = `rural-payments-${this.authType}`
+    this.baseURL = this.getBaseURL()
   }
 }

--- a/app/data-sources/rural-payments/RuralPaymentsBusiness.js
+++ b/app/data-sources/rural-payments/RuralPaymentsBusiness.js
@@ -84,7 +84,7 @@ export class RuralPaymentsBusiness extends RuralPayments {
   }
 
   async getOrganisationIdBySBI(sbi) {
-    if (this.gatewayType === 'external') {
+    if (this.isExternalRoute()) {
       return this.extractOrgIdFromDefraIdToken(sbi)
     }
     return (await this.organisationSearchBySbi(sbi)).id

--- a/app/data-sources/rural-payments/RuralPaymentsCustomer.js
+++ b/app/data-sources/rural-payments/RuralPaymentsCustomer.js
@@ -13,7 +13,7 @@ const KITS_CUSTOMER_SEARCH_FIELD = {
 
 export class RuralPaymentsCustomer extends RuralPayments {
   async getPersonIdByCRN(crn) {
-    if (this.gatewayType === 'external') {
+    if (this.isExternalRoute()) {
       const response = await this.getExternalPerson()
       return response?.id
     }
@@ -76,7 +76,7 @@ export class RuralPaymentsCustomer extends RuralPayments {
   }
 
   async getPersonByPersonId(personId) {
-    if (this.gatewayType === 'external') {
+    if (this.authType === 'external') {
       personId = config.get('kits.external.personIdOverride')
     }
     const response = await this.get(`person/${personId}/summary`)

--- a/app/graphql/context.js
+++ b/app/graphql/context.js
@@ -11,6 +11,7 @@ import { Permissions } from '../data-sources/static/permissions.js'
 import { BadRequest } from '../errors/graphql.js'
 import { logger } from '../logger/logger.js'
 import { db } from '../mongo.js'
+import { config } from '../config.js'
 
 export const extractOrgIdFromDefraIdToken = (sbi, token) => {
   const { payload } = jwt.decode(token, { complete: true })
@@ -36,16 +37,31 @@ export async function context({ request }) {
     traceId: request.traceId
   })
 
+  const gatewayType = request.headers['gateway-type'] || 'internal'
+
   const datasourceOptions = [
     { logger: requestLogger },
     {
       request,
-      gatewayType: request.headers['gateway-type'] || 'internal'
+      gatewayType
     }
   ]
 
+  const ruralPaymentsBusinessServiceAccount = new RuralPaymentsBusiness(
+    { logger: requestLogger },
+    {
+      gatewayType: 'service-account',
+      request: {
+        headers: {
+          email: config.get('kits.dalServiceAccountEmail')
+        }
+      }
+    }
+  )
+
   return {
     auth,
+    gatewayType,
     requestLogger,
     db,
     dataSources: {
@@ -66,7 +82,13 @@ export async function context({ request }) {
       }),
       mongoBusiness: new MongoBusiness({
         modelOrCollection: db.collection('businesses')
-      })
+      }),
+      serviceAccount: {
+        // Service account only currently supported for ruralPaymentsBusiness.  Other ruralPayments datasources
+        // should be added here too if the need arises, alongside a getXXXDataSource-style helper (see
+        // getRuralPaymentsBusinessDataSource in resolvers/business/common.js) for resolvers to pick the right instance.
+        ruralPaymentsBusiness: ruralPaymentsBusinessServiceAccount
+      }
     }
   }
 }

--- a/app/graphql/context.js
+++ b/app/graphql/context.js
@@ -37,36 +37,36 @@ export async function context({ request }) {
     traceId: request.traceId
   })
 
-  const gatewayType = request.headers['gateway-type'] || 'internal'
-
   const datasourceOptions = [
     { logger: requestLogger },
     {
-      request,
-      gatewayType
+      request
     }
   ]
 
-  const ruralPaymentsBusinessServiceAccount = new RuralPaymentsBusiness(
+  const internalServiceAccountDatasourceOptions = [
     { logger: requestLogger },
     {
-      gatewayType: 'service-account',
       request: {
+        ...request,
         headers: {
-          email: config.get('kits.dalServiceAccountEmail')
+          ...request.headers,
+          'service-account':
+            request.headers['service-account'] || config.get('kits.dalServiceAccountEmail')
         }
       }
     }
-  )
+  ]
+
+  const standardAuthRuralPaymentsBusiness = new RuralPaymentsBusiness(...datasourceOptions)
 
   return {
     auth,
-    gatewayType,
     requestLogger,
     db,
     dataSources: {
       permissions: new Permissions({ logger: requestLogger }),
-      ruralPaymentsBusiness: new RuralPaymentsBusiness(...datasourceOptions),
+      ruralPaymentsBusiness: standardAuthRuralPaymentsBusiness,
       ruralPaymentsCustomer: new RuralPaymentsCustomer(...datasourceOptions),
       ruralPaymentsReferenceData: new RuralPaymentsReferenceData(...datasourceOptions),
       hitachiPayments: new HitachiPayments({
@@ -87,7 +87,10 @@ export async function context({ request }) {
         // Service account only currently supported for ruralPaymentsBusiness.  Other ruralPayments datasources
         // should be added here too if the need arises, alongside a getXXXDataSource-style helper (see
         // getRuralPaymentsBusinessDataSource in resolvers/business/common.js) for resolvers to pick the right instance.
-        ruralPaymentsBusiness: ruralPaymentsBusinessServiceAccount
+        ruralPaymentsBusiness:
+          standardAuthRuralPaymentsBusiness.authType === 'external'
+            ? new RuralPaymentsBusiness(...internalServiceAccountDatasourceOptions)
+            : null
       }
     }
   }

--- a/app/graphql/resolvers/business/business-land.js
+++ b/app/graphql/resolvers/business/business-land.js
@@ -9,6 +9,7 @@ import {
   transformTotalParcels
 } from '../../../transformers/rural-payments/lms.js'
 import { validateDateInput } from '../../../utils/date.js'
+import { getRuralPaymentsBusinessDataSource } from './common.js'
 
 export const BusinessLand = {
   summary({ organisationId }, { date }) {
@@ -66,11 +67,11 @@ export const BusinessLand = {
     )
   },
 
-  async parcelLandUses({ sbi }, { sheetId, parcelId, date = new Date() }, { dataSources }) {
+  async parcelLandUses({ sbi }, { sheetId, parcelId, date = new Date() }, context) {
     validateDateInput(date)
 
     return transformLandUses(
-      await dataSources.ruralPaymentsBusiness.getLandUseByBusinessParcel(
+      await getRuralPaymentsBusinessDataSource(context).getLandUseByBusinessParcel(
         sbi,
         sheetId,
         parcelId,

--- a/app/graphql/resolvers/business/business-land.js
+++ b/app/graphql/resolvers/business/business-land.js
@@ -71,12 +71,10 @@ export const BusinessLand = {
     validateDateInput(date)
 
     return transformLandUses(
-      await getRuralPaymentsBusinessDataSource(context).getLandUseByBusinessParcel(
-        sbi,
-        sheetId,
-        parcelId,
-        date
-      )
+      await getRuralPaymentsBusinessDataSource({
+        ...context,
+        useServiceAccountForExternal: true
+      }).getLandUseByBusinessParcel(sbi, sheetId, parcelId, date)
     )
   }
 }

--- a/app/graphql/resolvers/business/business.js
+++ b/app/graphql/resolvers/business/business.js
@@ -11,6 +11,7 @@ import {
   transformOrganisationCustomers,
   transformOrganisationToBusiness
 } from '../../../transformers/rural-payments/business.js'
+import { getRuralPaymentsBusinessDataSource } from './common.js'
 
 export const Business = {
   async info({ organisationId, info }, __, { dataSources }) {
@@ -25,9 +26,9 @@ export const Business = {
     return { organisationId, sbi }
   },
 
-  async countyParishHoldings({ sbi }, __, { dataSources }) {
+  async countyParishHoldings({ sbi }, __, context) {
     const countyParishHoldings =
-      await dataSources.ruralPaymentsBusiness.getCountyParishHoldingsBySBI(sbi)
+      await getRuralPaymentsBusinessDataSource(context).getCountyParishHoldingsBySBI(sbi)
 
     return transformCountyParishHoldings(countyParishHoldings)
   },
@@ -61,14 +62,14 @@ export const Business = {
     return transformOrganisationCustomer(customer)
   },
 
-  async agreements({ sbi }, _, { dataSources }) {
-    const agreements = await dataSources.ruralPaymentsBusiness.getAgreementsBySBI(sbi)
+  async agreements({ sbi }, _, context) {
+    const agreements = await getRuralPaymentsBusinessDataSource(context).getAgreementsBySBI(sbi)
 
     return transformAgreements(agreements)
   },
 
-  async applications({ sbi }, _, { dataSources }) {
-    const applications = await dataSources.ruralPaymentsBusiness.getApplicationsBySBI(sbi)
+  async applications({ sbi }, _, context) {
+    const applications = await getRuralPaymentsBusinessDataSource(context).getApplicationsBySBI(sbi)
 
     return transformApplications(applications)
   },

--- a/app/graphql/resolvers/business/business.js
+++ b/app/graphql/resolvers/business/business.js
@@ -27,8 +27,10 @@ export const Business = {
   },
 
   async countyParishHoldings({ sbi }, __, context) {
-    const countyParishHoldings =
-      await getRuralPaymentsBusinessDataSource(context).getCountyParishHoldingsBySBI(sbi)
+    const countyParishHoldings = await getRuralPaymentsBusinessDataSource({
+      ...context,
+      useServiceAccountForExternal: true
+    }).getCountyParishHoldingsBySBI(sbi)
 
     return transformCountyParishHoldings(countyParishHoldings)
   },
@@ -63,13 +65,19 @@ export const Business = {
   },
 
   async agreements({ sbi }, _, context) {
-    const agreements = await getRuralPaymentsBusinessDataSource(context).getAgreementsBySBI(sbi)
+    const agreements = await getRuralPaymentsBusinessDataSource({
+      ...context,
+      useServiceAccountForExternal: true
+    }).getAgreementsBySBI(sbi)
 
     return transformAgreements(agreements)
   },
 
   async applications({ sbi }, _, context) {
-    const applications = await getRuralPaymentsBusinessDataSource(context).getApplicationsBySBI(sbi)
+    const applications = await getRuralPaymentsBusinessDataSource({
+      ...context,
+      useServiceAccountForExternal: true
+    }).getApplicationsBySBI(sbi)
 
     return transformApplications(applications)
   },

--- a/app/graphql/resolvers/business/common.js
+++ b/app/graphql/resolvers/business/common.js
@@ -51,6 +51,23 @@ export async function retrieveOrgIdBySbi(sbi, { mongoBusiness, ruralPaymentsBusi
   )
 }
 
+// Some fields must always be resolved against the internal gateway using the DAL service
+// account, even when the request itself arrived via the external gateway. Resolvers for those
+// fields should call this instead of reading dataSources.ruralPaymentsBusiness directly.
+export function getRuralPaymentsBusinessDataSource({ gatewayType, dataSources }) {
+  if (gatewayType !== 'external') {
+    return dataSources.ruralPaymentsBusiness
+  }
+
+  if (!dataSources.serviceAccount?.ruralPaymentsBusiness) {
+    throw new Error(
+      'getRuralPaymentsBusinessDataSource misconfigured: dataSources.serviceAccount.ruralPaymentsBusiness is missing'
+    )
+  }
+
+  return dataSources.serviceAccount.ruralPaymentsBusiness
+}
+
 const validateLockUnlockInput = (input) => {
   if (!input.reason && !input.note) {
     throw new Error('Reason and/or note are required')

--- a/app/graphql/resolvers/business/common.js
+++ b/app/graphql/resolvers/business/common.js
@@ -54,8 +54,12 @@ export async function retrieveOrgIdBySbi(sbi, { mongoBusiness, ruralPaymentsBusi
 // Some fields must always be resolved against the internal gateway using the DAL service
 // account, even when the request itself arrived via the external gateway. Resolvers for those
 // fields should call this instead of reading dataSources.ruralPaymentsBusiness directly.
-export function getRuralPaymentsBusinessDataSource({ gatewayType, dataSources }) {
-  if (gatewayType !== 'external') {
+export function getRuralPaymentsBusinessDataSource({
+  gatewayType,
+  dataSources,
+  useServiceAccountForExternal = false
+}) {
+  if (gatewayType !== 'external' || !useServiceAccountForExternal) {
     return dataSources.ruralPaymentsBusiness
   }
 

--- a/app/graphql/resolvers/business/common.js
+++ b/app/graphql/resolvers/business/common.js
@@ -55,21 +55,15 @@ export async function retrieveOrgIdBySbi(sbi, { mongoBusiness, ruralPaymentsBusi
 // account, even when the request itself arrived via the external gateway. Resolvers for those
 // fields should call this instead of reading dataSources.ruralPaymentsBusiness directly.
 export function getRuralPaymentsBusinessDataSource({
-  gatewayType,
   dataSources,
   useServiceAccountForExternal = false
 }) {
-  if (gatewayType !== 'external' || !useServiceAccountForExternal) {
-    return dataSources.ruralPaymentsBusiness
+  if (dataSources.serviceAccount.ruralPaymentsBusiness && useServiceAccountForExternal) {
+    // This is an externally routed request (service account datasource is only configured for external routes) and
+    // the resolver has explicitly asked for the service account
+    return dataSources.serviceAccount.ruralPaymentsBusiness
   }
-
-  if (!dataSources.serviceAccount?.ruralPaymentsBusiness) {
-    throw new Error(
-      'getRuralPaymentsBusinessDataSource misconfigured: dataSources.serviceAccount.ruralPaymentsBusiness is missing'
-    )
-  }
-
-  return dataSources.serviceAccount.ruralPaymentsBusiness
+  return dataSources.ruralPaymentsBusiness
 }
 
 const validateLockUnlockInput = (input) => {

--- a/app/routes/healthy.js
+++ b/app/routes/healthy.js
@@ -8,7 +8,7 @@ import { throttle } from '../utils/throttle.js'
 const ruralPaymentsHealthCheck = async () => {
   const ruralPaymentsBusiness = new RuralPaymentsBusiness(
     { logger },
-    { headers: { email: config.get('healthCheck.ruralPaymentsPortalEmail') } }
+    { request: { headers: { email: config.get('healthCheck.ruralPaymentsPortalEmail') } } }
   )
   return ruralPaymentsBusiness.getOrganisationById(
     config.get('healthCheck.ruralPaymentsInternalOrganisationId')

--- a/app/utils/health/rural-payments.js
+++ b/app/utils/health/rural-payments.js
@@ -1,4 +1,5 @@
 import { StatusCodes } from 'http-status-codes'
+import { config } from '../../config.js'
 import { RURALPAYMENTS_API_ERROR_001 } from '../../logger/codes.js'
 import { logger } from '../../logger/logger.js'
 import { RuralPaymentsReferenceData } from '../../data-sources/rural-payments/RuralPaymentsReferenceData.js'
@@ -8,18 +9,21 @@ const runRuralPaymentsCheck = async (type) => {
     // Rural payment requests must be initiated by a real user, so health check calls will never have the necessary
     // credentials to successfully invoke an endpoint (when auth is turned on).  The goal of the health check is to
     // verify that the upstream is available and serving responses.   A forbidden response is still a response, so
-    // the goal of the health check is a 200 when auth is disabled, or a 403 when auth is enabled.  Given this, no
-    // authentication headers will be set and the 'healthcheck' header will instruct the datasource to submit the
-    // request, even without authorisation.
+    // the goal of the health check is a 200 when auth is disabled, or a 403 when auth is enabled.  The 'healthcheck'
+    // header instructs the datasource to submit the request without setting real credentials, even without
+    // authorisation. gatewayType is now derived from request headers rather than an explicit option, so each check
+    // carries just enough of a signal to route to the gateway it's meant to test: the internal check identifies
+    // itself with the DAL service-account header, the external check with a placeholder x-forwarded-authorization
+    // header (its value is never decoded, since the 'healthcheck' header short-circuits addAuthentication first).
+    const headers =
+      type === 'external'
+        ? { healthcheck: true, 'x-forwarded-authorization': 'healthcheck' }
+        : { healthcheck: true, 'service-account': config.get('kits.dalServiceAccountEmail') }
+
     const ruralPaymentsReferenceData = new RuralPaymentsReferenceData(
       { logger },
       {
-        gatewayType: type,
-        request: {
-          headers: {
-            healthcheck: true
-          }
-        }
+        request: { headers }
       }
     )
     await ruralPaymentsReferenceData.getReferenceData('legalstatus')

--- a/compose.yml
+++ b/compose.yml
@@ -49,6 +49,7 @@ services:
       KITS_EXTERNAL_GATEWAY_URL: http://upstream-mock:3100/extapi/
       KITS_GATEWAY_TIMEOUT_MS: 3000
       KITS_DISABLE_MTLS: true
+      KITS_DAL_SERVICE_ACCOUNT_EMAIL: test@example.com
       HITACHI_GATEWAY_URL: http://upstream-mock:3100/api/
       HITACHI_TIMEOUT_MS: 3000
       DAL_REQUEST_TIMEOUT_MS: 3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.15.3",
+  "version": "2.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.15.3",
+      "version": "2.16.0",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
@@ -5354,9 +5354,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6118,21 +6118,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -6148,9 +6161,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8369,9 +8382,9 @@
       }
     },
     "node_modules/graphql-config/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11778,9 +11791,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -12679,9 +12692,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14536,17 +14549,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.15.3",
+  "version": "2.16.0",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/graphql/business.test.js
+++ b/test/graphql/business.test.js
@@ -7,152 +7,181 @@ import { mockOrganisationSearch } from './helpers.js'
 import { makeTestQuery } from './makeTestQuery.js'
 
 const query = `#graphql
-    query BusinessTest {
-      business(sbi: "sbi") {
-        organisationId
-        sbi
-        info {
-          name
-          address {
-            pafOrganisationName
-            line1
-            line2
-            line3
-            line4
-            line5
-            buildingNumberRange
-            buildingName
-            flatName
-            street
-            city
-            county
-            postalCode
-            country
-            uprn
-            dependentLocality
-            doubleDependentLocality
-            typeId
-          }
-          email {
-            address
-          }
-          legalStatus {
-            code
-            type
-          }
-          phone {
-            mobile
-            landline
-          }
-          traderNumber
-          type {
-            code
-            type
-          }
-          vat
-          vendorNumber
-        }
-        land {
-          parcels(date: "2025-05-04") {
-            id
-            sheetId
-            parcelId
-            area
-            pendingDigitisation
-          }
-          parcel(sheetId: "sheetId", parcelId: "parcelId", date: "2025-05-04") {
-            id
-            sheetId
-            parcelId
-            area
-            pendingDigitisation
-            effectiveToDate
-            effectiveFromDate
-          }
-          parcelLandUses(sheetId: "sheetId", parcelId: "parcelId", date: "2025-05-04") {
-            code
-            startDate
-            endDate
-            insertDate
-            deleteDate
-            area
-            length
-          }
-          parcelCovers(sheetId: "sheetId", parcelId: "parcelId", date: "2025-05-04") {
-            id
-            name
-            area
-            code
-            isBpsEligible
-          }
-          summary(date: "2025-05-04") {
-            arableLandArea
-            permanentCropsArea
-            permanentGrasslandArea
-            totalArea
-            totalParcels
-          }
-        }
-        customers {
-          personId
-          firstName
-          lastName
-          crn
-          role
-        }
-        customer(crn: "customerReference") {
-          personId
-          firstName
-          lastName
-          crn
-          role
-          permissionGroups {
-            id
-            level
-            functions
-          }
-        }
-        countyParishHoldings {
-          cphNumber
-          parish
-          startDate
-          endDate
-          species
-          xCoordinate
-          yCoordinate
-        }
-        applications {
-          sbi
-          id
-          subjectId
-          year
-          name
-          moduleCode
-          scheme
-          statusCodeP
-          statusCodeS
-          status
-          submissionDate
-          portalStatusP
-          portalStatusS
-          portalStatus
-          active
-          transitionId
-          transitionName
-          agreementReferences
-          transitionHistory {
-            id
-            name
-            timestamp
-            checkStatus
-          }
-        }
+query BusinessTest {
+  business(sbi: "sbi") {
+    organisationId
+    sbi
+    info {
+      name
+      address {
+        pafOrganisationName
+        line1
+        line2
+        line3
+        line4
+        line5
+        buildingNumberRange
+        buildingName
+        flatName
+        street
+        city
+        county
+        postalCode
+        country
+        uprn
+        dependentLocality
+        doubleDependentLocality
+        typeId
+      }
+      email {
+        address
+      }
+      legalStatus {
+        code
+        type
+      }
+      phone {
+        mobile
+        landline
+      }
+      traderNumber
+      type {
+        code
+        type
+      }
+      vat
+      vendorNumber
+    }
+    land {
+      parcels(date: "2025-05-04") {
+        id
+        sheetId
+        parcelId
+        area
+        pendingDigitisation
+      }
+      parcel(sheetId: "sheetId", parcelId: "parcelId", date: "2025-05-04") {
+        id
+        sheetId
+        parcelId
+        area
+        pendingDigitisation
+        effectiveToDate
+        effectiveFromDate
+      }
+      parcelLandUses(sheetId: "sheetId", parcelId: "parcelId", date: "2025-05-04") {
+        code
+        startDate
+        endDate
+        insertDate
+        deleteDate
+        area
+        length
+      }
+      parcelCovers(sheetId: "sheetId", parcelId: "parcelId", date: "2025-05-04") {
+        id
+        name
+        area
+        code
+        isBpsEligible
+      }
+      summary(date: "2025-05-04") {
+        arableLandArea
+        permanentCropsArea
+        permanentGrasslandArea
+        totalArea
+        totalParcels
       }
     }
-  `
+    customers {
+      personId
+      firstName
+      lastName
+      crn
+      role
+    }
+    customer(crn: "customerReference") {
+      personId
+      firstName
+      lastName
+      crn
+      role
+      permissionGroups {
+        id
+        level
+        functions
+      }
+    }
+    countyParishHoldings {
+      cphNumber
+      parish
+      startDate
+      endDate
+      species
+      xCoordinate
+      yCoordinate
+    }
+    applications {
+      sbi
+      id
+      subjectId
+      year
+      name
+      moduleCode
+      scheme
+      statusCodeP
+      statusCodeS
+      status
+      submissionDate
+      portalStatusP
+      portalStatusS
+      portalStatus
+      active
+      transitionId
+      transitionName
+      agreementReferences
+      transitionHistory {
+        id
+        name
+        timestamp
+        checkStatus
+      }
+    }
+    agreements {
+      contractId
+      name
+      status
+      contractType
+      schemeYear
+      startDate
+      endDate
+      paymentSchedules {
+        optionCode
+        optionDescription
+        commitmentGroupStartDate
+        commitmentGroupEndDate
+        year
+        sheetName
+        parcelName
+        actionArea
+        actionMTL
+        actionUnits
+        parcelTotalArea
+        startDate
+        endDate
+      }
+    }
+  }
+}
+`
 
-const setupNock = (v1) => {
-  v1.get('/organisation/organisationId').reply(200, {
+const setupNock = (upstream, headers) => {
+  // Headers should either be a single email header (internal route) or an Authorization/CRN combination (external)
+  // Calling match header directly on 'upstream' applies the match to every interceptor registered on it, so this only needs
+  // setting once rather than on each individual .get() call below.
+  Object.entries(headers).forEach(([name, value]) => upstream.matchHeader(name, value))
+
+  upstream.get('/organisation/organisationId').reply(200, {
     _data: {
       id: 'organisationId',
       sbi: 'sbi',
@@ -195,7 +224,7 @@ const setupNock = (v1) => {
     }
   })
 
-  v1.get('/authorisation/organisation/organisationId').reply(200, {
+  upstream.get('/authorisation/organisation/organisationId').reply(200, {
     _data: [
       {
         id: 'personId',
@@ -208,7 +237,7 @@ const setupNock = (v1) => {
     ]
   })
 
-  v1.get('/lms/organisation/organisationId/parcels/historic/04-May-25').reply(200, [
+  upstream.get('/lms/organisation/organisationId/parcels/historic/04-May-25').reply(200, [
     {
       id: 'id',
       sheetId: 'sheetId',
@@ -218,7 +247,7 @@ const setupNock = (v1) => {
     }
   ])
 
-  v1.get('/lms/organisation/organisationId/parcel-details/historic/04-May-25').reply(200, [
+  upstream.get('/lms/organisation/organisationId/parcel-details/historic/04-May-25').reply(200, [
     {
       sheetId: 'sheetId',
       parcelId: 'parcelId',
@@ -227,29 +256,40 @@ const setupNock = (v1) => {
     }
   ])
 
-  v1.get(
-    '/lms/organisation/organisationId/parcel/sheet-id/sheetId/parcel-id/parcelId/historic/04-May-25/land-covers'
-  ).reply(200, {
-    features: [
-      {
-        id: 'id',
-        properties: {
-          area: 1,
-          code: 'code',
-          name: 'name',
-          isBpsEligible: true
+  upstream
+    .get(
+      '/lms/organisation/organisationId/parcel/sheet-id/sheetId/parcel-id/parcelId/historic/04-May-25/land-covers'
+    )
+    .reply(200, {
+      features: [
+        {
+          id: 'id',
+          properties: {
+            area: 1,
+            code: 'code',
+            name: 'name',
+            isBpsEligible: true
+          }
         }
-      }
-    ]
-  })
+      ]
+    })
 
-  v1.get('/lms/organisation/organisationId/covers-summary/historic/04-May-25').reply(200, [
+  upstream.get('/lms/organisation/organisationId/covers-summary/historic/04-May-25').reply(200, [
     { name: 'Arable Land', area: 1 },
     { name: 'Permanent Grassland', area: 1 },
     { name: 'Permanent Crops', area: 1 }
   ])
+}
 
-  v1.get(`/SitiAgriApi/cv/landUseByBusinessParcel/sheet/sheetId/parcel/parcelId/sbi/sbi/list`)
+// The fields backed by the queries below use getRuralPaymentsBusinessDataSource (see resolvers/business/common.js), so they
+// are always resolved against the internal gateway.  The email param will always be either the calling user's
+// email address for internal requests, or the dal service account for external requests that have been re-routed
+const setupAnnotatedFieldsNock = (internalUpstream, email) => {
+  // All requests should have an email header
+  internalUpstream.matchHeader('email', email)
+
+  internalUpstream
+    .get(`/SitiAgriApi/cv/landUseByBusinessParcel/sheet/sheetId/parcel/parcelId/sbi/sbi/list`)
     .query(({ pointInTime }) => /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(pointInTime))
     .reply(200, {
       data: [
@@ -272,7 +312,8 @@ const setupNock = (v1) => {
       errorString: null
     })
 
-  v1.get('/SitiAgriApi/cv/cphByBusiness/sbi/sbi/list')
+  internalUpstream
+    .get('/SitiAgriApi/cv/cphByBusiness/sbi/sbi/list')
     .query(({ pointInTime }) => /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(pointInTime))
     .reply(200, {
       data: [
@@ -292,7 +333,7 @@ const setupNock = (v1) => {
       ]
     })
 
-  v1.get('/SitiAgriApi/cv/appByBusiness/sbi/sbi/list').reply(200, {
+  internalUpstream.get('/SitiAgriApi/cv/appByBusiness/sbi/sbi/list').reply(200, {
     data: [
       {
         sbi: 'sbi',
@@ -319,6 +360,37 @@ const setupNock = (v1) => {
             transition_name: 'Transition Name',
             dt_transition: '2025-05-04T02:00:00:123+0100',
             check_status: 'Check Status'
+          }
+        ]
+      }
+    ]
+  })
+
+  internalUpstream.get('/SitiAgriApi/cv/agreementsByBusiness/sbi/sbi/list').reply(200, {
+    data: [
+      {
+        contract_id: 'contract-1',
+        agreement_name: 'Agreement Name',
+        status: 'Status',
+        contract_type: 'Contract Type',
+        scheme_year: 2025,
+        start_date: '2025-01-01T00:00:00:000+0000',
+        end_date: '2025-12-31T00:00:00:000+0000',
+        payment_schedules: [
+          {
+            option_code: 'Option Code',
+            option_description: 'Option Description',
+            commitment_group_start_date: '2025-01-01T00:00:00:000+0000',
+            commitment_group_end_date: '2025-12-31T00:00:00:000+0000',
+            year: 2025,
+            sheet_name: 'sheetId',
+            parcel_name: 'parcelId',
+            action_area: 1,
+            action_mtl: 1,
+            action_units: 1,
+            parcel_total_area: 1,
+            payment_schedule_start_date: '2025-01-01T00:00:00:000+0000',
+            payment_schedule_end_date: '2025-12-31T00:00:00:000+0000'
           }
         ]
       }
@@ -355,18 +427,29 @@ describe('Query.business internal', () => {
   })
 
   test('authenticated external', async () => {
-    const v1 = nock(config.get('kits.external.gatewayUrl'))
-    setupNock(v1)
+    configMockPath['kits.dalServiceAccountEmail'] = 'dal-service-account@example.com'
 
     // For external requests we extract org id from token but don't verify.
     // so any jwt with a valid relationships array works
+    const crn = '123'
     const tokenValue = jwt.sign(
       {
-        contactId: '123',
+        contactId: crn,
         relationships: ['organisationId:sbi']
       },
       'test-secret'
     )
+
+    const externalKitsGateway = nock(config.get('kits.external.gatewayUrl'))
+    const internalKitsGateway = nock(config.get('kits.internal.gatewayUrl'))
+    setupNock(externalKitsGateway, {
+      Authorization: tokenValue,
+      crn
+    })
+
+    // Ensure that the service account annotated fields are routed to the internal gateway
+    // via the DAL service account, even though this request arrived via external.
+    setupAnnotatedFieldsNock(internalKitsGateway, 'dal-service-account@example.com')
 
     const result = await makeTestQuery(query, {
       'gateway-type': 'external',
@@ -522,6 +605,34 @@ describe('Query.business internal', () => {
                 }
               ]
             }
+          ],
+          agreements: [
+            {
+              contractId: 'contract-1',
+              name: 'Agreement Name',
+              status: 'Status',
+              contractType: 'Contract Type',
+              schemeYear: 2025,
+              startDate: '2025-01-01T00:00:00.000Z',
+              endDate: '2025-12-31T00:00:00.000Z',
+              paymentSchedules: [
+                {
+                  optionCode: 'Option Code',
+                  optionDescription: 'Option Description',
+                  commitmentGroupStartDate: '2025-01-01T00:00:00.000Z',
+                  commitmentGroupEndDate: '2025-12-31T00:00:00.000Z',
+                  year: 2025,
+                  sheetName: 'sheetId',
+                  parcelName: 'parcelId',
+                  actionArea: 0.0001,
+                  actionMTL: 1,
+                  actionUnits: 1,
+                  parcelTotalArea: 0.0001,
+                  startDate: '2025-01-01T00:00:00.000Z',
+                  endDate: '2025-12-31T00:00:00.000Z'
+                }
+              ]
+            }
           ]
         }
       }
@@ -531,9 +642,12 @@ describe('Query.business internal', () => {
   })
 
   test('authenticated internal', async () => {
-    const v1 = nock(config.get('kits.internal.gatewayUrl'))
-    setupNock(v1)
-    mockOrganisationSearch(v1)
+    const internalKitsGateway = nock(config.get('kits.internal.gatewayUrl'))
+    setupNock(internalKitsGateway, { email: 'test@defra.gov.uk' })
+    // Internal requests also route the annotated fields to the internal gateway, but using the caller's own identity
+    // (no service-account swap - the directive is a no-op here).
+    setupAnnotatedFieldsNock(internalKitsGateway, 'test@defra.gov.uk')
+    mockOrganisationSearch(internalKitsGateway)
 
     const result = await makeTestQuery(query)
 
@@ -686,6 +800,34 @@ describe('Query.business internal', () => {
                 }
               ]
             }
+          ],
+          agreements: [
+            {
+              contractId: 'contract-1',
+              name: 'Agreement Name',
+              status: 'Status',
+              contractType: 'Contract Type',
+              schemeYear: 2025,
+              startDate: '2025-01-01T00:00:00.000Z',
+              endDate: '2025-12-31T00:00:00.000Z',
+              paymentSchedules: [
+                {
+                  optionCode: 'Option Code',
+                  optionDescription: 'Option Description',
+                  commitmentGroupStartDate: '2025-01-01T00:00:00.000Z',
+                  commitmentGroupEndDate: '2025-12-31T00:00:00.000Z',
+                  year: 2025,
+                  sheetName: 'sheetId',
+                  parcelName: 'parcelId',
+                  actionArea: 0.0001,
+                  actionMTL: 1,
+                  actionUnits: 1,
+                  parcelTotalArea: 0.0001,
+                  startDate: '2025-01-01T00:00:00.000Z',
+                  endDate: '2025-12-31T00:00:00.000Z'
+                }
+              ]
+            }
           ]
         }
       }
@@ -695,9 +837,10 @@ describe('Query.business internal', () => {
   })
 
   test('is able to query land parcels with no date', async () => {
-    const v1 = nock(config.get('kits.internal.gatewayUrl'))
-    mockOrganisationSearch(v1)
-    setupNock(v1)
+    const internalKitsGateway = nock(config.get('kits.internal.gatewayUrl'))
+    mockOrganisationSearch(internalKitsGateway)
+    setupNock(internalKitsGateway, { email: 'test@defra.gov.uk' })
+    setupAnnotatedFieldsNock(internalKitsGateway, 'test@defra.gov.uk')
 
     const currentDate = new Date()
     const day = currentDate.toLocaleString('en-US', { day: '2-digit' }) // 01
@@ -705,117 +848,106 @@ describe('Query.business internal', () => {
     const year = currentDate.toLocaleString('en-US', { year: '2-digit' }) // "25"
     const formattedDate = `${day}-${month}-${year}`
 
-    v1.get(`/lms/organisation/organisationId/parcels/historic/${formattedDate}`).reply(200, [
-      {
-        id: 'id',
-        sheetId: 'sheetId',
-        parcelId: 'parcelId',
-        area: 1,
-        pendingDigitisation: true
-      }
-    ])
-
-    v1.get(`/lms/organisation/organisationId/parcel-details/historic/${formattedDate}`).reply(200, [
-      {
-        sheetId: 'sheetId',
-        parcelId: 'parcelId',
-        validFrom: 1636934401682,
-        validTo: 1636934392140
-      }
-    ])
-
-    v1.get(
-      `/lms/organisation/organisationId/parcel/sheet-id/sheetId/parcel-id/parcelId/historic/${formattedDate}/land-covers`
-    ).reply(200, {
-      features: [
+    internalKitsGateway
+      .get(`/lms/organisation/organisationId/parcels/historic/${formattedDate}`)
+      .matchHeader('email', 'test@defra.gov.uk')
+      .reply(200, [
         {
           id: 'id',
-          properties: {
-            area: 1,
-            code: 'code',
-            name: 'name',
-            isBpsEligible: true
-          }
+          sheetId: 'sheetId',
+          parcelId: 'parcelId',
+          area: 1,
+          pendingDigitisation: true
         }
-      ]
-    })
+      ])
 
-    v1.get(`/lms/organisation/organisationId/covers-summary/historic/${formattedDate}`).reply(200, [
-      { name: 'Arable Land', area: 1 },
-      { name: 'Permanent Grassland', area: 1 },
-      { name: 'Permanent Crops', area: 1 }
-    ])
-
-    v1.get(
-      `/SitiAgriApi/cv/landUseByBusinessParcel/sheet/sheetId/parcel/parcelId/sbi/sbi/list`
-    ).reply(200, {
-      data: [
+    internalKitsGateway
+      .get(`/lms/organisation/organisationId/parcel-details/historic/${formattedDate}`)
+      .matchHeader('email', 'test@defra.gov.uk')
+      .reply(200, [
         {
-          sbi: 'sbi',
-          dt_insert: '2021-03-01T12:09:09:009+0000',
-          dt_delete: '9999-12-31T00:00:00:000+0000',
-          sheet_name: 'sheetId',
-          parcel_name: 'parcelId',
-          campaign: 2021,
-          lu_code: 'code',
-          landuse: 'SCRUB - UNGRAZEABLE',
-          start_date: '2021-01-01T00:00:00:000+0000',
-          end_date: '9999-12-31T00:00:00:000+0000',
-          area: 0,
-          length: null
+          sheetId: 'sheetId',
+          parcelId: 'parcelId',
+          validFrom: 1636934401682,
+          validTo: 1636934392140
         }
-      ],
-      success: true,
-      errorString: null
-    })
+      ])
 
-    const parcelsQuery = `#graphql
-      query BusinessTest {
-          business(sbi: "sbi") {
-            land {
-              parcels {
-                id
-                sheetId
-                parcelId
-                area
-                pendingDigitisation
-              }
-              parcel(sheetId: "sheetId", parcelId: "parcelId") {
-                id
-                sheetId
-                parcelId
-                area
-                pendingDigitisation
-                effectiveToDate
-                effectiveFromDate
-              }
-              parcelCovers(sheetId: "sheetId", parcelId: "parcelId") {
-                id
-                name
-                area
-                code
-                isBpsEligible
-              }
-              parcelLandUses(sheetId: "sheetId", parcelId: "parcelId") {
-                code
-                startDate
-                endDate
-                insertDate
-                deleteDate
-                area
-                length
-              }
-              summary {
-                arableLandArea
-                permanentCropsArea
-                permanentGrasslandArea
-                totalArea
-                totalParcels
-              }
+    internalKitsGateway
+      .get(
+        `/lms/organisation/organisationId/parcel/sheet-id/sheetId/parcel-id/parcelId/historic/${formattedDate}/land-covers`
+      )
+      .matchHeader('email', 'test@defra.gov.uk')
+      .reply(200, {
+        features: [
+          {
+            id: 'id',
+            properties: {
+              area: 1,
+              code: 'code',
+              name: 'name',
+              isBpsEligible: true
             }
           }
+        ]
+      })
+
+    internalKitsGateway
+      .get(`/lms/organisation/organisationId/covers-summary/historic/${formattedDate}`)
+      .matchHeader('email', 'test@defra.gov.uk')
+      .reply(200, [
+        { name: 'Arable Land', area: 1 },
+        { name: 'Permanent Grassland', area: 1 },
+        { name: 'Permanent Crops', area: 1 }
+      ])
+
+    const parcelsQuery = `#graphql
+    query BusinessTest {
+      business(sbi: "sbi") {
+        land {
+          parcels {
+            id
+            sheetId
+            parcelId
+            area
+            pendingDigitisation
+          }
+          parcel(sheetId: "sheetId", parcelId: "parcelId") {
+            id
+            sheetId
+            parcelId
+            area
+            pendingDigitisation
+            effectiveToDate
+            effectiveFromDate
+          }
+          parcelCovers(sheetId: "sheetId", parcelId: "parcelId") {
+            id
+            name
+            area
+            code
+            isBpsEligible
+          }
+          parcelLandUses(sheetId: "sheetId", parcelId: "parcelId") {
+            code
+            startDate
+            endDate
+            insertDate
+            deleteDate
+            area
+            length
+          }
+          summary {
+            arableLandArea
+            permanentCropsArea
+            permanentGrasslandArea
+            totalArea
+            totalParcels
+          }
         }
-      `
+      }
+    }
+    `
     const result = await makeTestQuery(parcelsQuery)
     expect(result).toEqual({
       data: {

--- a/test/unit/app/config.test.js
+++ b/test/unit/app/config.test.js
@@ -57,6 +57,96 @@ describe('config', () => {
     expect(config.get('oidc.timeoutMs')).toBe(null)
   })
 
+  it('should read values from the environment when supplied', async () => {
+    process.env.NODE_ENV = 'development'
+    process.env.ENVIRONMENT = 'test'
+    process.env.HTTPS_PROXY = 'http://proxy.example.com'
+    process.env.PORT = '4000'
+    process.env.LOG_LEVEL = 'debug'
+    process.env.ALL_SCHEMA_ON = 'true'
+    process.env.GRAPHQL_DASHBOARD_ENABLED = 'true'
+    process.env.DAL_REQUEST_TIMEOUT_MS = '1500'
+    process.env.OIDC_JWKS_URI = 'https://example.com/jwks'
+    process.env.OIDC_JWKS_TIMEOUT_MS = '5000'
+    process.env.DISABLE_AUTH = 'false'
+    process.env.ADMIN_AD_GROUP_ID = 'admin-group-id'
+    process.env.CONSOLIDATED_VIEW_AD_GROUP_ID = 'consolidated-view-group-id'
+    process.env.SINGLE_FRONT_DOOR_AD_GROUP_ID = 'single-front-door-group-id'
+    process.env.SFI_REFORM_AD_GROUP_ID = 'sfi-reform-group-id'
+    process.env.HEALTH_CHECK_ENABLED = 'true'
+    process.env.HEALTH_CHECK_RP_PORTAL_EMAIL = 'healthcheck@example.com'
+    process.env.HEALTH_CHECK_RP_INTERNAL_ORGANISATION_ID = 'org-id'
+    process.env.HEALTH_CHECK_RP_THROTTLE_TIME_MS = '1000'
+    process.env.KITS_INTERNAL_CONNECTION_CERT = 'internal-cert-value'
+    process.env.KITS_INTERNAL_CONNECTION_KEY = 'internal-key-value'
+    process.env.KITS_INTERNAL_GATEWAY_URL = 'https://internal.example.com'
+    process.env.KITS_EXTERNAL_CONNECTION_CERT = 'external-cert-value'
+    process.env.KITS_EXTERNAL_CONNECTION_KEY = 'external-key-value'
+    process.env.KITS_EXTERNAL_GATEWAY_URL = 'https://external.example.com'
+    process.env.KIT_EXT_PERSON_ID_OVERRIDE = '123456'
+    process.env.KITS_DISABLE_MTLS = 'true'
+    process.env.KITS_CA_CERT = 'ca-cert-value'
+    process.env.KITS_GATEWAY_TIMEOUT_MS = '2000'
+    process.env.KITS_REQUEST_PAGE_SIZE = '50'
+    process.env.KITS_DAL_SERVICE_ACCOUNT_EMAIL = 'service-account@example.com'
+    process.env.HITACHI_DISABLE_AUTH = 'false'
+    process.env.HITACHI_BASE_URL = 'https://hitachi.example.com'
+    process.env.HITACHI_TIMEOUT_MS = '2500'
+    process.env.HITACHI_ENTRA_TENANT_ID = 'hitachi-tenant-id'
+    process.env.HITACHI_ENTRA_CLIENT_ID = 'hitachi-client-id'
+    process.env.HITACHI_ENTRA_CLIENT_SECRET = 'hitachi-client-secret'
+    process.env.MONGO_URI = 'mongodb://example.com:27017'
+    process.env.MONGO_DATABASE = 'test-database'
+    process.env.MONGO_RETRY_WRITES = 'false'
+    process.env.MONGO_READ_PREFERENCE = 'secondary'
+    process.env.MONGO_TIMEOUT_MS = '4000'
+
+    const { config } = await loadFreshConfig()
+
+    expect(config.get('nodeEnv')).toBe('development')
+    expect(config.get('cdp.env')).toBe('test')
+    expect(config.get('cdp.httpsProxy')).toBe('http://proxy.example.com')
+    expect(config.get('port')).toBe(4000)
+    expect(config.get('logLevel')).toBe('debug')
+    expect(config.get('allSchemaOn')).toBe(true)
+    expect(config.get('graphqlDashboardEnabled')).toBe(true)
+    expect(config.get('requestTimeoutMs')).toBe(1500)
+    expect(config.get('oidc.jwksURI')).toBe('https://example.com/jwks')
+    expect(config.get('oidc.timeoutMs')).toBe(5000)
+    expect(config.get('auth.disabled')).toBe(false)
+    expect(config.get('auth.groups.ADMIN')).toBe('admin-group-id')
+    expect(config.get('auth.groups.CONSOLIDATED_VIEW')).toBe('consolidated-view-group-id')
+    expect(config.get('auth.groups.SINGLE_FRONT_DOOR')).toBe('single-front-door-group-id')
+    expect(config.get('auth.groups.SFI_REFORM')).toBe('sfi-reform-group-id')
+    expect(config.get('healthCheck.enabled')).toBe(true)
+    expect(config.get('healthCheck.ruralPaymentsPortalEmail')).toBe('healthcheck@example.com')
+    expect(config.get('healthCheck.ruralPaymentsInternalOrganisationId')).toBe('org-id')
+    expect(config.get('healthCheck.throttleTimeMs')).toBe(1000)
+    expect(config.get('kits.internal.connectionCert')).toBe('internal-cert-value')
+    expect(config.get('kits.internal.connectionKey')).toBe('internal-key-value')
+    expect(config.get('kits.internal.gatewayUrl')).toBe('https://internal.example.com')
+    expect(config.get('kits.external.connectionCert')).toBe('external-cert-value')
+    expect(config.get('kits.external.connectionKey')).toBe('external-key-value')
+    expect(config.get('kits.external.gatewayUrl')).toBe('https://external.example.com')
+    expect(config.get('kits.external.personIdOverride')).toBe(123456)
+    expect(config.get('kits.disableMTLS')).toBe(true)
+    expect(config.get('kits.caCert')).toBe('ca-cert-value')
+    expect(config.get('kits.gatewayTimeoutMs')).toBe(2000)
+    expect(config.get('kits.requestPageSize')).toBe(50)
+    expect(config.get('kits.dalServiceAccountEmail')).toBe('service-account@example.com')
+    expect(config.get('hitachi.disableAuth')).toBe(false)
+    expect(config.get('hitachi.baseUrl')).toBe('https://hitachi.example.com')
+    expect(config.get('hitachi.timeoutMs')).toBe(2500)
+    expect(config.get('hitachi.entra.tenantId')).toBe('hitachi-tenant-id')
+    expect(config.get('hitachi.entra.clientId')).toBe('hitachi-client-id')
+    expect(config.get('hitachi.entra.clientSecret')).toBe('hitachi-client-secret')
+    expect(config.get('mongo.mongoUrl')).toBe('mongodb://example.com:27017')
+    expect(config.get('mongo.databaseName')).toBe('test-database')
+    expect(config.get('mongo.mongoOptions.retryWrites')).toBe(false)
+    expect(config.get('mongo.mongoOptions.readPreference')).toBe('secondary')
+    expect(config.get('mongo.mongoOptions.timeoutMS')).toBe(4000)
+  })
+
   it('should throw an error with any invalid combinations of env vars', async () => {
     // These are in a single test to avoid race conditions when setting env vars
     process.env.KITS_DISABLE_MTLS = 'true'
@@ -87,6 +177,14 @@ describe('config', () => {
       'healthCheck.ruralPaymentsInternalOrganisationId: must be of type String'
     ]
     await expect(loadFreshConfig()).rejects.toEqual(new Error(expectedErrors.join('\n')))
+    process.env.HEALTH_CHECK_ENABLED = 'false'
+
+    // KITS_DAL_SERVICE_ACCOUNT_EMAIL check
+    const dalServiceAccountEmail = process.env.KITS_DAL_SERVICE_ACCOUNT_EMAIL
+    delete process.env.KITS_DAL_SERVICE_ACCOUNT_EMAIL
+    expectedErrors = ['kits.dalServiceAccountEmail: must be of type String']
+    await expect(loadFreshConfig()).rejects.toEqual(new Error(expectedErrors.join('\n')))
+    process.env.KITS_DAL_SERVICE_ACCOUNT_EMAIL = dalServiceAccountEmail
   })
 
   it('should throw on invalid values', async () => {

--- a/test/unit/app/context.test.js
+++ b/test/unit/app/context.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, jest } from '@jest/globals'
+import { config } from '../../../app/config.js'
 
 const getAuthMock = jest.fn()
 const getRequestingGroupMock = jest.fn()
@@ -71,12 +72,59 @@ describe('context', () => {
       traceId: 'trace-1'
     })
     expect(result.auth).toEqual({ user: 'test-user' })
+    expect(result.gatewayType).toBe('external')
     expect(result.requestLogger).toBeDefined()
     expect(result.dataSources.permissions.type).toBe('Permissions')
     expect(result.dataSources.ruralPaymentsBusiness).toEqual({})
     expect(result.dataSources.ruralPaymentsCustomer).toEqual({})
     expect(result.dataSources.mongoBusiness).toEqual({})
     expect(result.dataSources.mongoCustomer).toEqual({})
+    expect(result.dataSources.serviceAccount.ruralPaymentsBusiness).toEqual({})
+  })
+
+  describe('gatewayType', () => {
+    test('defaults to internal when no gateway-type header is present', async () => {
+      getAuthMock.mockResolvedValue({ user: 'test-user' })
+      const request = { headers: {} }
+
+      const result = await context({ request })
+
+      expect(result.gatewayType).toBe('internal')
+    })
+
+    test('reflects the gateway-type header when present', async () => {
+      getAuthMock.mockResolvedValue({ user: 'test-user' })
+      const request = { headers: { 'gateway-type': 'external' } }
+
+      const result = await context({ request })
+
+      expect(result.gatewayType).toBe('external')
+    })
+  })
+
+  describe('serviceAccount', () => {
+    test('constructs a RuralPaymentsBusiness instance forced to service-account with the configured service-account email', async () => {
+      getAuthMock.mockResolvedValue({ user: 'test-user' })
+      loggerChild.mockReturnValue({ log: jest.fn() })
+      const configGetSpy = jest
+        .spyOn(config, 'get')
+        .mockImplementation((path) =>
+          path === 'kits.dalServiceAccountEmail' ? 'dal-service-account@example.com' : undefined
+        )
+      const request = { headers: { 'gateway-type': 'external' } }
+
+      await context({ request })
+
+      expect(RuralPaymentsBusinessMock).toHaveBeenCalledWith(
+        { logger: expect.anything() },
+        {
+          gatewayType: 'service-account',
+          request: { headers: { email: 'dal-service-account@example.com' } }
+        }
+      )
+
+      configGetSpy.mockRestore()
+    })
   })
 
   describe('hitachiPayments', () => {

--- a/test/unit/app/context.test.js
+++ b/test/unit/app/context.test.js
@@ -72,38 +72,17 @@ describe('context', () => {
       traceId: 'trace-1'
     })
     expect(result.auth).toEqual({ user: 'test-user' })
-    expect(result.gatewayType).toBe('external')
     expect(result.requestLogger).toBeDefined()
     expect(result.dataSources.permissions.type).toBe('Permissions')
     expect(result.dataSources.ruralPaymentsBusiness).toEqual({})
     expect(result.dataSources.ruralPaymentsCustomer).toEqual({})
     expect(result.dataSources.mongoBusiness).toEqual({})
     expect(result.dataSources.mongoCustomer).toEqual({})
-    expect(result.dataSources.serviceAccount.ruralPaymentsBusiness).toEqual({})
-  })
-
-  describe('gatewayType', () => {
-    test('defaults to internal when no gateway-type header is present', async () => {
-      getAuthMock.mockResolvedValue({ user: 'test-user' })
-      const request = { headers: {} }
-
-      const result = await context({ request })
-
-      expect(result.gatewayType).toBe('internal')
-    })
-
-    test('reflects the gateway-type header when present', async () => {
-      getAuthMock.mockResolvedValue({ user: 'test-user' })
-      const request = { headers: { 'gateway-type': 'external' } }
-
-      const result = await context({ request })
-
-      expect(result.gatewayType).toBe('external')
-    })
+    expect(result.dataSources.serviceAccount.ruralPaymentsBusiness).toBeNull()
   })
 
   describe('serviceAccount', () => {
-    test('constructs a RuralPaymentsBusiness instance forced to service-account with the configured service-account email', async () => {
+    test('constructs a service-account RuralPaymentsBusiness instance, injecting the configured DAL email as the "service-account" header, when the standard instance resolves to an external authType', async () => {
       getAuthMock.mockResolvedValue({ user: 'test-user' })
       loggerChild.mockReturnValue({ log: jest.fn() })
       const configGetSpy = jest
@@ -111,19 +90,70 @@ describe('context', () => {
         .mockImplementation((path) =>
           path === 'kits.dalServiceAccountEmail' ? 'dal-service-account@example.com' : undefined
         )
-      const request = { headers: { 'gateway-type': 'external' } }
+      RuralPaymentsBusinessMock.mockImplementationOnce(() => ({ authType: 'external' }))
+      RuralPaymentsBusinessMock.mockImplementationOnce(() => ({
+        marker: 'service-account-instance'
+      }))
+      const request = { headers: { 'x-forwarded-authorization': 'token123' } }
+
+      const result = await context({ request })
+
+      expect(RuralPaymentsBusinessMock).toHaveBeenCalledTimes(2)
+      expect(RuralPaymentsBusinessMock).toHaveBeenNthCalledWith(
+        2,
+        { logger: expect.anything() },
+        {
+          request: {
+            ...request,
+            headers: { ...request.headers, 'service-account': 'dal-service-account@example.com' }
+          }
+        }
+      )
+      expect(result.dataSources.serviceAccount.ruralPaymentsBusiness).toEqual({
+        marker: 'service-account-instance'
+      })
+
+      configGetSpy.mockRestore()
+    })
+
+    test('preserves an existing "service-account" header instead of overwriting it with the configured DAL email', async () => {
+      getAuthMock.mockResolvedValue({ user: 'test-user' })
+      loggerChild.mockReturnValue({ log: jest.fn() })
+      const configGetSpy = jest
+        .spyOn(config, 'get')
+        .mockImplementation((path) =>
+          path === 'kits.dalServiceAccountEmail' ? 'dal-service-account@example.com' : undefined
+        )
+      RuralPaymentsBusinessMock.mockImplementationOnce(() => ({ authType: 'external' }))
+      RuralPaymentsBusinessMock.mockImplementationOnce(() => ({}))
+      const request = {
+        headers: {
+          'x-forwarded-authorization': 'token123',
+          'service-account': 'already-set@example.com'
+        }
+      }
 
       await context({ request })
 
-      expect(RuralPaymentsBusinessMock).toHaveBeenCalledWith(
+      expect(RuralPaymentsBusinessMock).toHaveBeenNthCalledWith(
+        2,
         { logger: expect.anything() },
-        {
-          gatewayType: 'service-account',
-          request: { headers: { email: 'dal-service-account@example.com' } }
-        }
+        { request: { ...request, headers: { ...request.headers } } }
       )
 
       configGetSpy.mockRestore()
+    })
+
+    test('does not construct a service-account data source when the standard instance does not resolve to an external authType', async () => {
+      getAuthMock.mockResolvedValue({ user: 'test-user' })
+      loggerChild.mockReturnValue({ log: jest.fn() })
+      RuralPaymentsBusinessMock.mockImplementationOnce(() => ({ authType: 'internal' }))
+      const request = { headers: { email: 'user@example.com' } }
+
+      const result = await context({ request })
+
+      expect(RuralPaymentsBusinessMock).toHaveBeenCalledTimes(1)
+      expect(result.dataSources.serviceAccount.ruralPaymentsBusiness).toBeNull()
     })
   })
 
@@ -143,7 +173,7 @@ describe('context', () => {
     test('Audit requesterId is undefined if no email header found', async () => {
       getAuthMock.mockResolvedValue({ user: 'test-user' })
       const request = {
-        headers: {}
+        headers: { 'x-forwarded-authorization': 'placeholder-token' }
       }
 
       const result = await context({ request })
@@ -153,7 +183,7 @@ describe('context', () => {
     test('Audit correlationId is extracted from request traceId', async () => {
       getAuthMock.mockResolvedValue({ user: 'test-user' })
       const request = {
-        headers: {},
+        headers: { 'x-forwarded-authorization': 'placeholder-token' },
         traceId: '111-222-333'
       }
 
@@ -164,7 +194,7 @@ describe('context', () => {
     test('Audit correlationId is undefined if no request traceId is found', async () => {
       getAuthMock.mockResolvedValue({ user: 'test-user' })
       const request = {
-        headers: {}
+        headers: { 'x-forwarded-authorization': 'placeholder-token' }
       }
 
       const result = await context({ request })
@@ -175,7 +205,7 @@ describe('context', () => {
       getAuthMock.mockResolvedValue({ user: 'test-user', groups: ['group-1', 'group-2'] })
       getRequestingGroupMock.mockReturnValue('SOME_AD_GROUP')
       const request = {
-        headers: {},
+        headers: { 'x-forwarded-authorization': 'placeholder-token' },
         traceId: '111-222-333'
       }
 
@@ -189,7 +219,7 @@ describe('context', () => {
       getAuthMock.mockResolvedValue({ user: 'test-user' })
       getRequestingGroupMock.mockReturnValue(undefined)
       const request = {
-        headers: {},
+        headers: { 'x-forwarded-authorization': 'placeholder-token' },
         traceId: '111-222-333'
       }
 

--- a/test/unit/data-sources/rural-payments/rural-payments-business.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments-business.test.js
@@ -76,7 +76,7 @@ describe('Rural Payments Business', () => {
   const datasourceOptions = [
     { logger },
     {
-      gatewayType: 'internal'
+      request: { headers: { email: 'test@test.test' } }
     }
   ]
   const ruralPaymentsBusiness = new RuralPaymentsBusiness(...datasourceOptions)
@@ -90,7 +90,6 @@ describe('Rural Payments Business', () => {
   const ruralPaymentsBusinessExt = new RuralPaymentsBusiness(
     { logger },
     {
-      gatewayType: 'external',
       request: {
         headers: {
           'x-forwarded-authorization': tokenValue

--- a/test/unit/data-sources/rural-payments/rural-payments-custom-fetch.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments-custom-fetch.test.js
@@ -71,14 +71,13 @@ describe('RuralPayments Custom Fetch', () => {
     const { RuralPayments } = await import(
       `../../../../app/data-sources/rural-payments/RuralPayments.js?update=${Date.now()}`
     )
-    const request = {}
+    const request = { headers: { email: 'test@test.test' } }
     const rp = new RuralPayments(config, {
-      request,
-      gatewayType: 'internal'
+      request
     })
 
     expect(rp.request).toBe(request)
-    expect(rp.gatewayType).toBe('internal')
+    expect(rp.authType).toBe('internal')
     expect(rp.baseURL).toBe(fakeInternalURL)
     const requestTls = {
       host: 'rp_kits_gateway_internal_url',
@@ -113,14 +112,13 @@ describe('RuralPayments Custom Fetch', () => {
     const { RuralPayments } = await import(
       `../../../../app/data-sources/rural-payments/RuralPayments.js?update=${Date.now()}`
     )
-    const request = {}
+    const request = { headers: { 'x-forwarded-authorization': 'token123' } }
     const rp = new RuralPayments(config, {
-      request,
-      gatewayType: 'external'
+      request
     })
 
     expect(rp.request).toBe(request)
-    expect(rp.gatewayType).toBe('external')
+    expect(rp.authType).toBe('external')
     expect(rp.baseURL).toBe(fakeExternalURL)
     const requestTls = {
       host: 'rp_kits_gateway_internal_url',
@@ -156,14 +154,13 @@ describe('RuralPayments Custom Fetch', () => {
     const { RuralPayments } = await import(
       `../../../../app/data-sources/rural-payments/RuralPayments.js?update=${Date.now()}`
     )
-    const request = {}
+    const request = { headers: { email: 'test@test.test' } }
     const rp = new RuralPayments(config, {
-      request,
-      gatewayType: 'internal'
+      request
     })
 
     expect(rp.request).toBe(request)
-    expect(rp.gatewayType).toBe('internal')
+    expect(rp.authType).toBe('internal')
     expect(rp.baseURL).toBe(fakeInternalURL)
 
     // check that the fetch works as expected with timeout, but without mTLS
@@ -187,14 +184,13 @@ describe('RuralPayments Custom Fetch', () => {
     const { RuralPayments } = await import(
       `../../../../app/data-sources/rural-payments/RuralPayments.js?update=${Date.now()}`
     )
-    const request = {}
+    const request = { headers: { 'x-forwarded-authorization': 'token123' } }
     const rp = new RuralPayments(config, {
-      request,
-      gatewayType: 'external'
+      request
     })
 
     expect(rp.request).toBe(request)
-    expect(rp.gatewayType).toBe('external')
+    expect(rp.authType).toBe('external')
     expect(rp.baseURL).toBe(fakeExternalURL)
 
     // check that the fetch works as expected with timeout, but without mTLS

--- a/test/unit/data-sources/rural-payments/rural-payments-customer.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments-customer.test.js
@@ -12,14 +12,13 @@ describe('Rural Payments Customer', () => {
   const datasourceOptions = [
     { logger },
     {
-      gatewayType: 'internal'
+      request: { headers: { email: 'test@test.test' } }
     }
   ]
   const ruralPaymentsCustomer = new RuralPaymentsCustomer(...datasourceOptions)
   const ruralPaymentsCustomerExt = new RuralPaymentsCustomer(
     { logger },
     {
-      gatewayType: 'external',
       request: {
         headers: {
           'x-forwarded-authorization': jwt.sign({ contactId: '11111111' }, 'secret', {
@@ -176,8 +175,8 @@ describe('Rural Payments Customer', () => {
         code: 'RURALPAYMENTS_API_NOT_FOUND_001',
         personId: 'nonexistentId',
         response: { body: {} },
-        gatewayType: 'internal',
-        request: undefined
+        gatewayType: 'rural-payments-internal',
+        request: { headers: { email: 'test@test.test' } }
       }
     )
   })

--- a/test/unit/data-sources/rural-payments/rural-payments-reference-data.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments-reference-data.test.js
@@ -4,7 +4,7 @@ import { RuralPaymentsReferenceData } from '../../../../app/data-sources/rural-p
 describe('RuralPaymentsReferenceData', () => {
   const ruralPaymentsReferenceData = new RuralPaymentsReferenceData(
     { logger: console },
-    { gatewayType: 'internal' }
+    { request: { headers: { email: 'test@test.test' } } }
   )
   const httpGet = jest.spyOn(ruralPaymentsReferenceData, 'get')
 

--- a/test/unit/data-sources/rural-payments/rural-payments.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments.test.js
@@ -209,7 +209,7 @@ describe('RuralPayments', () => {
       )
     })
 
-    test('throws error if gateway-type is not internal or external', () => {
+    test('throws error if gateway-type is not internal, external or service-account', () => {
       const invalidDataSourceOptions = [
         { logger },
         {
@@ -250,11 +250,69 @@ describe('RuralPayments', () => {
       )
     })
 
+    test('throws error if gateway type is service-account, but no email header is present', () => {
+      const rp = new RuralPayments(
+        { logger },
+        {
+          gatewayType: 'service-account',
+          request: {
+            headers: {}
+          }
+        }
+      )
+      const request = {}
+      const path = 'test-path'
+
+      expect(rp.willSendRequest(path, request)).rejects.toEqual(
+        new HttpError(StatusCodes.UNPROCESSABLE_ENTITY, {
+          extensions: {
+            message:
+              'Invalid request headers, must be either "email: {valid user email}" or "X-Forwarded-Authorization: {defra-id token}" & "gateway-type: external" headers'
+          }
+        })
+      )
+    })
+
     test('does not throw if gateway type is internal and email header is present', () => {
       const rp = new RuralPayments(
         { logger },
         {
           gatewayType: 'internal',
+          request: {
+            headers: {
+              email: 'test'
+            }
+          }
+        }
+      )
+      const request = {}
+      const path = 'test-path'
+
+      expect(rp.willSendRequest(path, request)).resolves.toBeUndefined()
+    })
+
+    test('does not throw if gateway type is service-account and email header is present', () => {
+      const rp = new RuralPayments(
+        { logger },
+        {
+          gatewayType: 'service-account',
+          request: {
+            headers: {
+              email: 'test'
+            }
+          }
+        }
+      )
+      const request = {}
+      const path = 'test-path'
+
+      expect(rp.willSendRequest(path, request)).resolves.toBeUndefined()
+    })
+
+    test('does not throw if no gateway-type defined (defaults to internal) and email header is present', () => {
+      const rp = new RuralPayments(
+        { logger },
+        {
           request: {
             headers: {
               email: 'test'
@@ -311,6 +369,7 @@ describe('RuralPayments', () => {
         expect.objectContaining({
           type: 'http',
           code: RURALPAYMENTS_API_REQUEST_001,
+          gatewayType: 'internal',
           request: {
             id: '123',
             method: 'GET',
@@ -329,6 +388,36 @@ describe('RuralPayments', () => {
           }),
           code: RURALPAYMENTS_API_REQUEST_001
         })
+      )
+    })
+
+    test('logs the external gatewayType', async () => {
+      const rp = new RuralPayments({ logger }, { gatewayType: 'external' })
+      const mockFn = jest.fn().mockResolvedValue({
+        response: { status: 200, headers: new Headers(), body: {} },
+        parsedBody: {}
+      })
+
+      await rp.trace('test-url', { id: '123', method: 'GET', headers: {} }, mockFn)
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '#datasource - Rural payments - response',
+        expect.objectContaining({ gatewayType: 'external' })
+      )
+    })
+
+    test('logs the service-account gatewayType', async () => {
+      const rp = new RuralPayments({ logger }, { gatewayType: 'service-account' })
+      const mockFn = jest.fn().mockResolvedValue({
+        response: { status: 200, headers: new Headers(), body: {} },
+        parsedBody: {}
+      })
+
+      await rp.trace('test-url', { id: '123', method: 'GET', headers: {} }, mockFn)
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '#datasource - Rural payments - response',
+        expect.objectContaining({ gatewayType: 'service-account' })
       )
     })
   })

--- a/test/unit/data-sources/rural-payments/rural-payments.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments.test.js
@@ -21,11 +21,9 @@ const datasourceOptions = [
   {
     request: {
       headers: {
-        'gateway-type': 'internal',
         email: 'test@test.test'
       }
-    },
-    gatewayType: 'internal'
+    }
   }
 ]
 
@@ -140,32 +138,103 @@ describe('RuralPayments', () => {
     })
   })
 
+  describe('authType resolution', () => {
+    test('resolves to internal when an email header is present', () => {
+      const rp = new RuralPayments(
+        { logger },
+        { request: { headers: { email: 'test@test.test' } } }
+      )
+
+      expect(rp.authType).toBe('internal')
+    })
+
+    test('resolves to client-service-account when only a service-account header is present', () => {
+      const rp = new RuralPayments(
+        { logger },
+        { request: { headers: { 'service-account': 'dal-service-account@example.com' } } }
+      )
+
+      expect(rp.authType).toBe('client-service-account')
+    })
+
+    test('resolves to external when only an x-forwarded-authorization header is present', () => {
+      const rp = new RuralPayments(
+        { logger },
+        { request: { headers: { 'x-forwarded-authorization': 'token123' } } }
+      )
+
+      expect(rp.authType).toBe('external')
+    })
+
+    test('resolves to dal-service-account when both x-forwarded-authorization and service-account headers are present', () => {
+      const rp = new RuralPayments(
+        { logger },
+        {
+          request: {
+            headers: {
+              'x-forwarded-authorization': 'token123',
+              'service-account': 'dal-service-account@example.com'
+            }
+          }
+        }
+      )
+
+      expect(rp.authType).toBe('dal-service-account')
+    })
+
+    test('email always wins, regardless of what other auth headers are also present', () => {
+      const rp = new RuralPayments(
+        { logger },
+        {
+          request: {
+            headers: {
+              email: 'test@test.test',
+              'x-forwarded-authorization': 'token123',
+              'service-account': 'dal-service-account@example.com'
+            }
+          }
+        }
+      )
+
+      expect(rp.authType).toBe('internal')
+    })
+
+    test('throws if none of email, x-forwarded-authorization or service-account headers are present', () => {
+      expect(() => new RuralPayments({ logger }, { request: { headers: {} } })).toThrow(
+        new HttpError(StatusCodes.UNPROCESSABLE_ENTITY, {
+          extensions: {
+            message:
+              'Invalid request headers, must be either "email: {valid user email}" or "X-Forwarded-Authorization: {defra-id token}" & "gateway-type: external" headers'
+          }
+        })
+      )
+    })
+  })
+
   describe('willSendRequest', () => {
-    test('adds email & gateway type header from request headers & gateway type for internal requests', async () => {
+    test('adds email header from request headers for internal requests', async () => {
       const rp = new RuralPayments(...datasourceOptions)
-      const request = { headers: { 'gateway-type': 'internal', email: 'test@test.test' } }
+      const request = { headers: {} }
       const path = 'test-path'
 
       await rp.willSendRequest(path, request)
 
-      expect(request.headers).toEqual({ email: 'test@test.test', 'gateway-type': 'internal' })
+      expect(request.headers).toEqual({ email: 'test@test.test' })
       expect(logger.debug).toHaveBeenCalledWith('#datasource - Rural payments - request', {
         request: { ...request, url: 'https://rp_kits_gateway_internal_url/test-path' },
         code: RURALPAYMENTS_API_REQUEST_001
       })
     })
 
-    test('adds crn, Authorization & gateway type header from request headers for external requests', async () => {
+    test('adds crn & Authorization headers from x-forwarded-authorization for external requests', async () => {
       const token = jwt.sign({ contactId: 'test-crn' }, 'secret', {
         expiresIn: '1h'
       })
       const rp = new RuralPayments(
         { logger },
         {
-          gatewayType: 'external',
           request: {
             headers: {
-              'gateway-type': 'external',
               'x-forwarded-authorization': token
             }
           }
@@ -186,154 +255,38 @@ describe('RuralPayments', () => {
       })
     })
 
-    test('throws error if external request headers are missing', () => {
+    test('adds email header from the service-account value for dal-service-account requests', async () => {
       const rp = new RuralPayments(
         { logger },
         {
-          gatewayType: 'external',
           request: {
-            headers: {}
+            headers: {
+              'x-forwarded-authorization': 'token123',
+              'service-account': 'dal-service-account@example.com'
+            }
           }
         }
       )
       const request = { headers: {} }
       const path = 'test-path'
 
-      expect(rp.willSendRequest(path, request)).rejects.toEqual(
-        new HttpError(StatusCodes.UNPROCESSABLE_ENTITY, {
-          extensions: {
-            message:
-              'Invalid request headers, must be either "email: {valid user email}" or "X-Forwarded-Authorization: {defra-id token}" & "gateway-type: external" headers'
-          }
-        })
-      )
-    })
+      await rp.willSendRequest(path, request)
 
-    test('throws error if gateway-type is not internal, external or service-account', () => {
-      const invalidDataSourceOptions = [
-        { logger },
-        {
-          gatewayType: 'unsupported',
-          request: {
-            headers: {}
-          }
-        }
-      ]
-
-      expect(() => new RuralPayments(...invalidDataSourceOptions)).toThrow(
-        new BadRequest(
-          'gateway-type header must be one of internal or external received: unsupported'
-        )
-      )
-    })
-
-    test('throws error if gateway type is internal, but no email header is present', () => {
-      const rp = new RuralPayments(
-        { logger },
-        {
-          gatewayType: 'internal',
-          request: {
-            headers: {}
-          }
-        }
-      )
-      const request = {}
-      const path = 'test-path'
-
-      expect(rp.willSendRequest(path, request)).rejects.toEqual(
-        new HttpError(StatusCodes.UNPROCESSABLE_ENTITY, {
-          extensions: {
-            message:
-              'Invalid request headers, must be either "email: {valid user email}" or "X-Forwarded-Authorization: {defra-id token}" & "gateway-type: external" headers'
-          }
-        })
-      )
-    })
-
-    test('throws error if gateway type is service-account, but no email header is present', () => {
-      const rp = new RuralPayments(
-        { logger },
-        {
-          gatewayType: 'service-account',
-          request: {
-            headers: {}
-          }
-        }
-      )
-      const request = {}
-      const path = 'test-path'
-
-      expect(rp.willSendRequest(path, request)).rejects.toEqual(
-        new HttpError(StatusCodes.UNPROCESSABLE_ENTITY, {
-          extensions: {
-            message:
-              'Invalid request headers, must be either "email: {valid user email}" or "X-Forwarded-Authorization: {defra-id token}" & "gateway-type: external" headers'
-          }
-        })
-      )
-    })
-
-    test('does not throw if gateway type is internal and email header is present', () => {
-      const rp = new RuralPayments(
-        { logger },
-        {
-          gatewayType: 'internal',
-          request: {
-            headers: {
-              email: 'test'
-            }
-          }
-        }
-      )
-      const request = {}
-      const path = 'test-path'
-
-      expect(rp.willSendRequest(path, request)).resolves.toBeUndefined()
-    })
-
-    test('does not throw if gateway type is service-account and email header is present', () => {
-      const rp = new RuralPayments(
-        { logger },
-        {
-          gatewayType: 'service-account',
-          request: {
-            headers: {
-              email: 'test'
-            }
-          }
-        }
-      )
-      const request = {}
-      const path = 'test-path'
-
-      expect(rp.willSendRequest(path, request)).resolves.toBeUndefined()
-    })
-
-    test('does not throw if no gateway-type defined (defaults to internal) and email header is present', () => {
-      const rp = new RuralPayments(
-        { logger },
-        {
-          request: {
-            headers: {
-              email: 'test'
-            }
-          }
-        }
-      )
-      const request = {}
-      const path = 'test-path'
-
-      expect(rp.willSendRequest(path, request)).resolves.toBeUndefined()
+      expect(request.headers).toEqual({ email: 'dal-service-account@example.com' })
+      expect(logger.debug).toHaveBeenCalledWith('#datasource - Rural payments - request', {
+        request: { ...request, url: 'https://rp_kits_gateway_internal_url/test-path' },
+        code: RURALPAYMENTS_API_REQUEST_001
+      })
     })
 
     test('does not throw and sends the request unauthenticated when the healthcheck header is present', async () => {
       const rp = new RuralPayments(
         { logger },
         {
-          gatewayType: 'internal',
           request: {
             headers: {
-              healthcheck: true
+              healthcheck: true,
+              'service-account': 'dal-service-account@example.com'
             }
           }
         }
@@ -369,7 +322,7 @@ describe('RuralPayments', () => {
         expect.objectContaining({
           type: 'http',
           code: RURALPAYMENTS_API_REQUEST_001,
-          gatewayType: 'internal',
+          gatewayType: 'rural-payments-internal',
           request: {
             id: '123',
             method: 'GET',
@@ -392,7 +345,10 @@ describe('RuralPayments', () => {
     })
 
     test('logs the external gatewayType', async () => {
-      const rp = new RuralPayments({ logger }, { gatewayType: 'external' })
+      const rp = new RuralPayments(
+        { logger },
+        { request: { headers: { 'x-forwarded-authorization': 'token123' } } }
+      )
       const mockFn = jest.fn().mockResolvedValue({
         response: { status: 200, headers: new Headers(), body: {} },
         parsedBody: {}
@@ -402,12 +358,22 @@ describe('RuralPayments', () => {
 
       expect(logger.info).toHaveBeenCalledWith(
         '#datasource - Rural payments - response',
-        expect.objectContaining({ gatewayType: 'external' })
+        expect.objectContaining({ gatewayType: 'rural-payments-external' })
       )
     })
 
-    test('logs the service-account gatewayType', async () => {
-      const rp = new RuralPayments({ logger }, { gatewayType: 'service-account' })
+    test('logs the dal-service-account gatewayType', async () => {
+      const rp = new RuralPayments(
+        { logger },
+        {
+          request: {
+            headers: {
+              'x-forwarded-authorization': 'token123',
+              'service-account': 'dal-service-account@example.com'
+            }
+          }
+        }
+      )
       const mockFn = jest.fn().mockResolvedValue({
         response: { status: 200, headers: new Headers(), body: {} },
         parsedBody: {}
@@ -417,7 +383,7 @@ describe('RuralPayments', () => {
 
       expect(logger.info).toHaveBeenCalledWith(
         '#datasource - Rural payments - response',
-        expect.objectContaining({ gatewayType: 'service-account' })
+        expect.objectContaining({ gatewayType: 'rural-payments-dal-service-account' })
       )
     })
   })

--- a/test/unit/resolvers/business/business-land.test.js
+++ b/test/unit/resolvers/business/business-land.test.js
@@ -72,6 +72,9 @@ describe('BusinessLand', () => {
         getLandUseByBusinessParcel() {
           return getLandUseByBusinessParcelResult
         }
+      },
+      serviceAccount: {
+        ruralPaymentsBusiness: null
       }
     }
   })

--- a/test/unit/resolvers/business/business.test.js
+++ b/test/unit/resolvers/business/business.test.js
@@ -217,6 +217,9 @@ const dataSources = {
   mongoBusiness: {
     getOrgIdBySbi: jest.fn(),
     upsertOrgIdBySbi: jest.fn()
+  },
+  serviceAccount: {
+    ruralPaymentsBusiness: null
   }
 }
 

--- a/test/unit/resolvers/business/common.test.js
+++ b/test/unit/resolvers/business/common.test.js
@@ -4,7 +4,8 @@ import {
   businessAdditionalDetailsUpdateResolver,
   businessDetailsUpdateResolver,
   businessLockResolver,
-  businessUnlockResolver
+  businessUnlockResolver,
+  getRuralPaymentsBusinessDataSource
 } from '../../../../app/graphql/resolvers/business/common.js'
 
 describe('businessDetailsUpdateResolver', () => {
@@ -192,6 +193,46 @@ describe('businessLockResolver', () => {
 
     await expect(businessLockResolver(null, { input }, { dataSources, logger })).rejects.toThrow(
       'Reason and/or note are required'
+    )
+  })
+})
+
+describe('getRuralPaymentsBusinessDataSource', () => {
+  const internal = { getAgreementsBySBI: jest.fn() }
+  const serviceAccount = { getAgreementsBySBI: jest.fn() }
+
+  it('returns the internal data source for internal requests', () => {
+    const dataSources = { ruralPaymentsBusiness: internal }
+
+    expect(getRuralPaymentsBusinessDataSource({ gatewayType: 'internal', dataSources })).toBe(
+      internal
+    )
+  })
+
+  it('returns the internal data source when gatewayType is not set', () => {
+    const dataSources = { ruralPaymentsBusiness: internal }
+
+    expect(getRuralPaymentsBusinessDataSource({ dataSources })).toBe(internal)
+  })
+
+  it('returns the service-account data source for external requests', () => {
+    const dataSources = {
+      ruralPaymentsBusiness: internal,
+      serviceAccount: { ruralPaymentsBusiness: serviceAccount }
+    }
+
+    expect(getRuralPaymentsBusinessDataSource({ gatewayType: 'external', dataSources })).toBe(
+      serviceAccount
+    )
+  })
+
+  it('throws a descriptive error when the service-account data source is missing for external requests', () => {
+    const dataSources = { ruralPaymentsBusiness: internal }
+
+    expect(() =>
+      getRuralPaymentsBusinessDataSource({ gatewayType: 'external', dataSources })
+    ).toThrow(
+      'getRuralPaymentsBusinessDataSource misconfigured: dataSources.serviceAccount.ruralPaymentsBusiness is missing'
     )
   })
 })

--- a/test/unit/resolvers/business/common.test.js
+++ b/test/unit/resolvers/business/common.test.js
@@ -201,25 +201,16 @@ describe('getRuralPaymentsBusinessDataSource', () => {
   const standardDataSource = { getAgreementsBySBI: jest.fn() }
   const serviceAccountDataSource = { getAgreementsBySBI: jest.fn() }
 
-  it('maps internal to the standard data source, regardless of useServiceAccountForExternal', () => {
-    const dataSources = { ruralPaymentsBusiness: standardDataSource }
-
-    expect(
-      getRuralPaymentsBusinessDataSource({
-        gatewayType: 'internal',
-        dataSources,
-        useServiceAccountForExternal: true
-      })
-    ).toBe(standardDataSource)
-  })
-
-  it('returns the standard data source when gatewayType is not set', () => {
-    const dataSources = { ruralPaymentsBusiness: standardDataSource }
+  it('returns the standard data source when useServiceAccountForExternal is not provided', () => {
+    const dataSources = {
+      ruralPaymentsBusiness: standardDataSource,
+      serviceAccount: { ruralPaymentsBusiness: serviceAccountDataSource }
+    }
 
     expect(getRuralPaymentsBusinessDataSource({ dataSources })).toBe(standardDataSource)
   })
 
-  it('maps external to the standard data source when useServiceAccountForExternal is false', () => {
+  it('returns the standard data source when useServiceAccountForExternal is false', () => {
     const dataSources = {
       ruralPaymentsBusiness: standardDataSource,
       serviceAccount: { ruralPaymentsBusiness: serviceAccountDataSource }
@@ -227,25 +218,13 @@ describe('getRuralPaymentsBusinessDataSource', () => {
 
     expect(
       getRuralPaymentsBusinessDataSource({
-        gatewayType: 'external',
         dataSources,
         useServiceAccountForExternal: false
       })
     ).toBe(standardDataSource)
   })
 
-  it('defaults useServiceAccountForExternal to false when not provided', () => {
-    const dataSources = {
-      ruralPaymentsBusiness: standardDataSource,
-      serviceAccount: { ruralPaymentsBusiness: serviceAccountDataSource }
-    }
-
-    expect(getRuralPaymentsBusinessDataSource({ gatewayType: 'external', dataSources })).toBe(
-      standardDataSource
-    )
-  })
-
-  it('maps external to the service-account data source when useServiceAccountForExternal is true', () => {
+  it('returns the service-account data source when useServiceAccountForExternal is true and a service-account data source is configured', () => {
     const dataSources = {
       ruralPaymentsBusiness: standardDataSource,
       serviceAccount: { ruralPaymentsBusiness: serviceAccountDataSource }
@@ -253,25 +232,24 @@ describe('getRuralPaymentsBusinessDataSource', () => {
 
     expect(
       getRuralPaymentsBusinessDataSource({
-        gatewayType: 'external',
         dataSources,
         useServiceAccountForExternal: true
       })
     ).toBe(serviceAccountDataSource)
   })
 
-  it('throws a descriptive error when the service-account data source is missing and useServiceAccountForExternal is true', () => {
-    const dataSources = { ruralPaymentsBusiness: standardDataSource }
+  it('falls back to the standard data source when useServiceAccountForExternal is true but no service-account data source is configured (e.g. internal requests)', () => {
+    const dataSources = {
+      ruralPaymentsBusiness: standardDataSource,
+      serviceAccount: { ruralPaymentsBusiness: null }
+    }
 
-    expect(() =>
+    expect(
       getRuralPaymentsBusinessDataSource({
-        gatewayType: 'external',
         dataSources,
         useServiceAccountForExternal: true
       })
-    ).toThrow(
-      'getRuralPaymentsBusinessDataSource misconfigured: dataSources.serviceAccount.ruralPaymentsBusiness is missing'
-    )
+    ).toBe(standardDataSource)
   })
 })
 

--- a/test/unit/resolvers/business/common.test.js
+++ b/test/unit/resolvers/business/common.test.js
@@ -198,39 +198,77 @@ describe('businessLockResolver', () => {
 })
 
 describe('getRuralPaymentsBusinessDataSource', () => {
-  const internal = { getAgreementsBySBI: jest.fn() }
-  const serviceAccount = { getAgreementsBySBI: jest.fn() }
+  const standardDataSource = { getAgreementsBySBI: jest.fn() }
+  const serviceAccountDataSource = { getAgreementsBySBI: jest.fn() }
 
-  it('returns the internal data source for internal requests', () => {
-    const dataSources = { ruralPaymentsBusiness: internal }
+  it('maps internal to the standard data source, regardless of useServiceAccountForExternal', () => {
+    const dataSources = { ruralPaymentsBusiness: standardDataSource }
 
-    expect(getRuralPaymentsBusinessDataSource({ gatewayType: 'internal', dataSources })).toBe(
-      internal
-    )
+    expect(
+      getRuralPaymentsBusinessDataSource({
+        gatewayType: 'internal',
+        dataSources,
+        useServiceAccountForExternal: true
+      })
+    ).toBe(standardDataSource)
   })
 
-  it('returns the internal data source when gatewayType is not set', () => {
-    const dataSources = { ruralPaymentsBusiness: internal }
+  it('returns the standard data source when gatewayType is not set', () => {
+    const dataSources = { ruralPaymentsBusiness: standardDataSource }
 
-    expect(getRuralPaymentsBusinessDataSource({ dataSources })).toBe(internal)
+    expect(getRuralPaymentsBusinessDataSource({ dataSources })).toBe(standardDataSource)
   })
 
-  it('returns the service-account data source for external requests', () => {
+  it('maps external to the standard data source when useServiceAccountForExternal is false', () => {
     const dataSources = {
-      ruralPaymentsBusiness: internal,
-      serviceAccount: { ruralPaymentsBusiness: serviceAccount }
+      ruralPaymentsBusiness: standardDataSource,
+      serviceAccount: { ruralPaymentsBusiness: serviceAccountDataSource }
+    }
+
+    expect(
+      getRuralPaymentsBusinessDataSource({
+        gatewayType: 'external',
+        dataSources,
+        useServiceAccountForExternal: false
+      })
+    ).toBe(standardDataSource)
+  })
+
+  it('defaults useServiceAccountForExternal to false when not provided', () => {
+    const dataSources = {
+      ruralPaymentsBusiness: standardDataSource,
+      serviceAccount: { ruralPaymentsBusiness: serviceAccountDataSource }
     }
 
     expect(getRuralPaymentsBusinessDataSource({ gatewayType: 'external', dataSources })).toBe(
-      serviceAccount
+      standardDataSource
     )
   })
 
-  it('throws a descriptive error when the service-account data source is missing for external requests', () => {
-    const dataSources = { ruralPaymentsBusiness: internal }
+  it('maps external to the service-account data source when useServiceAccountForExternal is true', () => {
+    const dataSources = {
+      ruralPaymentsBusiness: standardDataSource,
+      serviceAccount: { ruralPaymentsBusiness: serviceAccountDataSource }
+    }
+
+    expect(
+      getRuralPaymentsBusinessDataSource({
+        gatewayType: 'external',
+        dataSources,
+        useServiceAccountForExternal: true
+      })
+    ).toBe(serviceAccountDataSource)
+  })
+
+  it('throws a descriptive error when the service-account data source is missing and useServiceAccountForExternal is true', () => {
+    const dataSources = { ruralPaymentsBusiness: standardDataSource }
 
     expect(() =>
-      getRuralPaymentsBusinessDataSource({ gatewayType: 'external', dataSources })
+      getRuralPaymentsBusinessDataSource({
+        gatewayType: 'external',
+        dataSources,
+        useServiceAccountForExternal: true
+      })
     ).toThrow(
       'getRuralPaymentsBusinessDataSource misconfigured: dataSources.serviceAccount.ruralPaymentsBusiness is missing'
     )

--- a/test/unit/utils/health/rural-payments.test.js
+++ b/test/unit/utils/health/rural-payments.test.js
@@ -1,4 +1,5 @@
 import { expect, jest } from '@jest/globals'
+import { config } from '../../../../app/config.js'
 
 const mockLogger = {
   logger: {
@@ -38,15 +39,23 @@ describe('Rural payments health check', () => {
     expect(RuralPaymentsReferenceDataMock).toHaveBeenCalledWith(
       { logger: mockLogger.logger },
       {
-        gatewayType: 'internal',
-        request: { headers: { healthcheck: true } }
+        request: {
+          headers: {
+            healthcheck: true,
+            'service-account': config.get('kits.dalServiceAccountEmail')
+          }
+        }
       }
     )
     expect(RuralPaymentsReferenceDataMock).toHaveBeenCalledWith(
       { logger: mockLogger.logger },
       {
-        gatewayType: 'external',
-        request: { headers: { healthcheck: true } }
+        request: {
+          headers: {
+            healthcheck: true,
+            'x-forwarded-authorization': 'healthcheck'
+          }
+        }
       }
     )
     expect(mockLogger.logger.info).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

Some upstream KITS endpoints (`agreements`, `applications`, `countyParishHoldings`, and `BusinessLand.parcelLandUses`) should always be called using the **internal** KITS gateway.

* If the request gateway type is **Internal** then the request is passed to the internal gateway using the supplied email.
* If the request gateway type is **External** then the DAL **service account** email address is used.

This has been implemented as follows:

* `app/config.js` — Added `kits.dalServiceAccountEmail` config value (env: `KITS_DAL_SERVICE_ACCOUNT_EMAIL`).
* `app/data-sources/rural-payments/RuralPayments.js`, `BaseRESTDataSource.js` — add the service-account gatewayType, and log the resolved gatewayType as the action field on request-completion logs.
* `app/graphql/resolvers/business/common.js` — new `getRuralPaymentsBusinessDataSource` helper. Returns  `dataSources.ruralPaymentsBusiness` for internal requests, and `dataSources.serviceAccount.ruralPaymentsBusiness` for external requests, throwing a descriptive error if the service-account data source isn't configured.
* `app/graphql/context.js` — builds a second `RuralPaymentsBusiness` instance per request, authenticated as the DAL service account (`config.kits.dalServiceAccountEmail`), with `gatewayType: 'service-account'` (routes to the internal gateway).
* `app/graphql/resolvers/business/business.js` — agreements, applications, and `countyParishHoldings` now call `getRuralPaymentsBusinessDataSource(context)` instead of reading `dataSources.ruralPaymentsBusiness` directly.
* `app/graphql/resolvers/business/business-land.js` — same change for `parcelLandUses`.

## Alternative approach considered but discarded

I considered adding a schema directive `@externalToServiceAccount`.  This would modify the context for any field annotated, so the dataSource used would be the service account datasource.   The resolver would not need any knowledge of the context it was being called in - the context would already be in the correct state.

Although initially this felt like a good solution, it was complicated and would fall down if we ever needed a single field to be resolved by two datasources - one with the service account and one without.

Given that this mapping is only needed in 4 places, the more explicit resolver level approach seemed like a more pragmatic approach.   If interested, that solution can be found on branch https://github.com/DEFRA/fcp-dal-api/tree/feat/dal-service-account (This will be retained until this PR is complete, before being deleted)


This resolves Jira ticket: [FCPDAL-395]


[FCPDAL-395]: https://eaflood.atlassian.net/browse/FCPDAL-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ