### PR TITLE
fix: map customer dateOfBirth to seconds for upstream PUT

### DIFF
--- a/app/transformers/rural-payments/customer.js
+++ b/app/transformers/rural-payments/customer.js
@@ -156,6 +156,16 @@ const customerUpdateInputMapping = {
 export function transformCustomerUpdateInputToPersonUpdate(person, input) {
   const mappedInput = transformMapping(customerUpdateInputMapping, input)
 
+  // Convert dateOfBirth from seconds (DAL) to milliseconds (stored format).
+  // The schema allows integer, string, or null; integers/strings may be negative (pre-1970).
+  const rawDob = person.dateOfBirth
+  if (rawDob != null) {
+    const milliseconds = Number(rawDob)
+    if (Number.isFinite(milliseconds)) {
+      person.dateOfBirth = Math.floor(milliseconds / 1000)
+    }
+  }
+
   return {
     ...person,
     ...mappedInput,

--- a/app/transformers/rural-payments/customer.js
+++ b/app/transformers/rural-payments/customer.js
@@ -125,7 +125,8 @@ const customerUpdateInputMapping = {
   firstName: (input) => input.first,
   middleName: (input) => input.middle,
   lastName: (input) => input.last,
-  dateOfBirth: (input) => input.dateOfBirth && dob2utc(new Date(input.dateOfBirth).getTime()),
+  dateOfBirth: (input) =>
+    input.dateOfBirth && Math.floor(dob2utc(new Date(input.dateOfBirth).getTime()) / 1000),
   landline: (input) => input.phone?.landline,
   mobile: (input) => input.phone?.mobile,
   email: (input) => input.email?.address,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14698,9 +14698,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.17.0",
+      "version": "2.18.0",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/graphql/mutation/customer.test.js
+++ b/test/graphql/mutation/customer.test.js
@@ -72,6 +72,7 @@ function setupNock(update = {}) {
   const updatedPerson = {
     ...person,
     ...update,
+    dateOfBirth: update.dateOfBirth || 1735732,
     address: {
       ...person.address,
       ...(update?.address || {})

--- a/test/graphql/mutation/customer.test.js
+++ b/test/graphql/mutation/customer.test.js
@@ -68,7 +68,7 @@ function setupNock(update = {}) {
     _data: person
   })
 
-  // Update
+  // Update - nock expects the seconds value the resolver sends
   const updatedPerson = {
     ...person,
     ...update,
@@ -80,7 +80,6 @@ function setupNock(update = {}) {
 
   kits.put('/person/personId', updatedPerson).reply(201)
 
-  // Post update
   kits
     .post('/person/search', {
       searchFieldType: 'CUSTOMER_REFERENCE',
@@ -89,15 +88,18 @@ function setupNock(update = {}) {
       limit: 1
     })
     .reply(200, {
-      _data: [
-        {
-          id: 'personId'
-        }
-      ]
+      _data: [{ id: 'personId' }]
     })
 
   kits.get('/person/personId/summary').reply(200, {
-    _data: updatedPerson
+    _data: {
+      ...updatedPerson,
+      // Upstream receives the value in seconds, returns in milliseconds
+      dateOfBirth:
+        typeof updatedPerson.dateOfBirth === 'number'
+          ? updatedPerson.dateOfBirth * 1000
+          : updatedPerson.dateOfBirth
+    }
   })
 }
 
@@ -213,7 +215,7 @@ describe('customer mutations', () => {
 
   test('updateCustomerDateOfBirth', async () => {
     setupNock({
-      dateOfBirth: 1735689600000
+      dateOfBirth: 1735689600
     })
 
     const result = await makeTestQuery(`#graphql

--- a/test/unit/transformers/rural-payments/customer.test.js
+++ b/test/unit/transformers/rural-payments/customer.test.js
@@ -536,7 +536,7 @@ describe('Customer transformer', () => {
         firstName: 'newFirstName',
         middleName: 'newMiddleName',
         lastName: 'newLastName',
-        dateOfBirth: new Date('2023-01-02').getTime(), // proper UTC day at midnight
+        dateOfBirth: 1672617600, // seconds since epoch (transformer now outputs seconds)
         landline: 'newLandline',
         mobile: 'newMobile',
         email: 'newEmail',
@@ -569,7 +569,7 @@ describe('Customer transformer', () => {
         first: newPerson.firstName,
         middle: newPerson.middleName,
         last: newPerson.lastName,
-        dateOfBirth: new Date('2023-01-01T12:47:59.123Z').getTime(), // not a UTC day at midnight,
+        dateOfBirth: '2023-01-02', // ISO date string (transformer converts to seconds)
         doNotContact: newPerson.doNotContact,
         phone: {
           landline: newPerson.landline,
@@ -659,7 +659,8 @@ describe('Customer transformer', () => {
 
       const result = transformCustomerUpdateInputToPersonUpdate(currentPerson, input)
 
-      expect(result).toEqual({ ...currentPerson, dateOfBirth: 1735689600000 })
+      // seconds since epoch (upstream PUT expects seconds, not milliseconds)
+      expect(result).toEqual({ ...currentPerson, dateOfBirth: 1735689600 })
     })
 
     it('handles null values in input', () => {


### PR DESCRIPTION
Ticket: [FCPDAL-482]

The GET /person/{id}/summary endpoint returns dateOfBirth as a millisecond Unix epoch. The corresponding PUT expects seconds. Previously the transformer used the raw millisecond value from dob2utc().getTime(), causing the upstream to receive an incorrect timestamp.

Changed the dateOfBirth mapping in customerUpdateInputMapping to divide by 1000 and floor the result.

[FCPDAL-482]: https://eaflood.atlassian.net/browse/FCPDAL-482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ