### PR TITLE
Chore: guard debug logging

### DIFF
--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -11,7 +11,6 @@ permissions:
 env:
   AWS_REGION: eu-west-2
   AWS_ACCOUNT_ID: '094954420758'
-  CUSTOM_TAG: 2.18.2
 
 jobs:
   build:

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -11,6 +11,7 @@ permissions:
 env:
   AWS_REGION: eu-west-2
   AWS_ACCOUNT_ID: '094954420758'
+  CUSTOM_TAG: 2.18.2
 
 jobs:
   build:

--- a/app/data-sources/BaseRESTDataSource.js
+++ b/app/data-sources/BaseRESTDataSource.js
@@ -120,7 +120,6 @@ export class BaseRESTDataSource extends RESTDataSource {
       response
     })
 
-    const debugLogStart = performance.now()
     this.logger.debug(`#datasource - ${this.name} - response detail`, {
       request: { ...request, url: url.toString() },
       response: {
@@ -129,12 +128,6 @@ export class BaseRESTDataSource extends RESTDataSource {
       },
       code: this.code,
       requestTimeMs
-    })
-
-    const duration = performance.now() - debugLogStart
-    this.logger.info(`#datasource - ${this.name} - debug log duration`, {
-      code: this.code,
-      requestTimeMs: duration
     })
 
     return result

--- a/app/data-sources/BaseRESTDataSource.js
+++ b/app/data-sources/BaseRESTDataSource.js
@@ -123,8 +123,7 @@ export class BaseRESTDataSource extends RESTDataSource {
       request: { ...request, url: url.toString() },
       response: {
         ...response,
-        body: result.parsedBody,
-        size: Buffer.byteLength(JSON.stringify(response.body))
+        body: result.parsedBody
       },
       code: this.code,
       requestTimeMs

--- a/app/data-sources/BaseRESTDataSource.js
+++ b/app/data-sources/BaseRESTDataSource.js
@@ -119,6 +119,8 @@ export class BaseRESTDataSource extends RESTDataSource {
       },
       response
     })
+
+    const debugLogStart = performance.now()
     this.logger.debug(`#datasource - ${this.name} - response detail`, {
       request: { ...request, url: url.toString() },
       response: {
@@ -127,6 +129,12 @@ export class BaseRESTDataSource extends RESTDataSource {
       },
       code: this.code,
       requestTimeMs
+    })
+
+    const duration = performance.now() - debugLogStart
+    this.logger.info(`#datasource - ${this.name} - debug log duration`, {
+      code: this.code,
+      requestTimeMs: duration
     })
 
     return result

--- a/app/logger/logger.js
+++ b/app/logger/logger.js
@@ -18,17 +18,17 @@ const logLevels = {
   trace: 4
 }
 
-// Runs first in the logger's format chain so a disabled level short-circuits
-// (logform/combine's cascade stops on a falsy return) before the JSON
-// serialisation format below ever executes, avoiding the full formatting
-// cost for calls like `logger.debug(...)` that no transport would accept.
-const levelGuard = format((info) => logger.isLevelEnabled(info.level) && info)
-
 export const logger = createLogger({
   level: config.get('logLevel'),
   transports: transportTypes,
   levels: logLevels,
-  format: format.combine(levelGuard(), format.json())
+  // A non-empty top-level format is required here: if `format` is omitted,
+  // winston falls back to its own default (`logform/json()`), which runs a
+  // full JSON.stringify of the whole info object on every log call -
+  // including disabled-level calls a transport will just drop. The real
+  // formatting (cdpSchemaTranslator, ecsFormat) already happens per-transport
+  // above, so this is intentionally a no-op.
+  format: format.combine()
 })
 
 process.on('exit', () => {

--- a/app/logger/logger.js
+++ b/app/logger/logger.js
@@ -18,10 +18,17 @@ const logLevels = {
   trace: 4
 }
 
+// Runs first in the logger's format chain so a disabled level short-circuits
+// (logform/combine's cascade stops on a falsy return) before the JSON
+// serialisation format below ever executes, avoiding the full formatting
+// cost for calls like `logger.debug(...)` that no transport would accept.
+const levelGuard = format((info) => logger.isLevelEnabled(info.level) && info)
+
 export const logger = createLogger({
   level: config.get('logLevel'),
   transports: transportTypes,
-  levels: logLevels
+  levels: logLevels,
+  format: format.combine(levelGuard(), format.json())
 })
 
 process.on('exit', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.19.0",
+      "version": "2.19.1",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
@@ -5354,9 +5354,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5367,13 +5367,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -8374,9 +8374,9 @@
       }
     },
     "node_modules/graphql-config/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8387,13 +8387,13 @@
       }
     },
     "node_modules/graphql-config/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -12684,9 +12684,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12707,13 +12707,13 @@
       }
     },
     "node_modules/nodemon/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",
@@ -84,11 +84,11 @@
     "latest-version": {
       "got": "11.8.6"
     },
-    "micromatch": "4.0.8",
-    "dset": "3.1.4",
+    "micromatch": "^4.0.8",
+    "dset": "^3.1.4",
     "js-yaml": "^4.2.0",
     "uuid": "^14.0.0",
-    "brace-expansion@1": "2.1.3",
-    "brace-expansion@5": "5.0.8"
+    "brace-expansion@1": "^2.1.3",
+    "brace-expansion@5": "^5.0.9"
   }
 }

--- a/test/unit/logger/logger.test.js
+++ b/test/unit/logger/logger.test.js
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals'
 import { v4 as uuidv4 } from 'uuid'
-import { format } from 'winston'
+import { createLogger, format, transports } from 'winston'
 import ConsoleTransportInstance from 'winston-transport'
 import { config } from '../../../app/config.js'
 
@@ -50,38 +50,34 @@ describe('logger', () => {
     expect(logger.transports[0].close).toHaveBeenCalled()
   })
 
-  describe('level-based JSON formatting guard', () => {
+  describe('top-level format', () => {
     let jsonTransformSpy
 
     beforeEach(() => {
-      // format.json() instances share this prototype transform (see logform/format.js),
-      // so spying here observes every JSON-formatting attempt made via format.json().
+      // format.json() instances share this prototype transform (see logform/format.js).
+      // Winston falls back to this exact format when `createLogger` is given no `format`
+      // option (see node_modules/winston/lib/winston/logger.js), stringifying the whole
+      // info object on every log call - including ones a transport will end up dropping.
       jsonTransformSpy = jest.spyOn(format.json.Format.prototype, 'transform')
     })
 
-    it('does not run JSON formatting for a disabled level (debug, with level=info)', async () => {
-      configMockPath.logLevel = 'info'
+    it('does not fall back to winston default JSON formatting', async () => {
       const { logger } = await loadFreshLogger()
 
-      logger.debug('this should be skipped before JSON formatting')
+      logger.info('this should not be JSON formatted at the logger level')
 
       expect(jsonTransformSpy).not.toHaveBeenCalled()
     })
 
-    it('runs JSON formatting for an enabled level (info, with level=info)', async () => {
-      configMockPath.logLevel = 'info'
-      const { logger } = await loadFreshLogger()
+    // Control: proves the spy above would actually catch the fallback if
+    // logger.js ever stopped passing a `format` option.
+    it('control: a logger created with no format option does fall back to JSON formatting', () => {
+      const controlLogger = createLogger({
+        level: 'info',
+        transports: [new transports.Console()]
+      })
 
-      logger.info('this should be JSON formatted')
-
-      expect(jsonTransformSpy).toHaveBeenCalled()
-    })
-
-    it('runs JSON formatting for debug once the level is raised to debug', async () => {
-      configMockPath.logLevel = 'debug'
-      const { logger } = await loadFreshLogger()
-
-      logger.debug('this should be JSON formatted')
+      controlLogger.info('this should be JSON formatted via the winston default')
 
       expect(jsonTransformSpy).toHaveBeenCalled()
     })

--- a/test/unit/logger/logger.test.js
+++ b/test/unit/logger/logger.test.js
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals'
-import ConsoleTransportInstance from 'winston-transport'
 import { v4 as uuidv4 } from 'uuid'
+import { format } from 'winston'
+import ConsoleTransportInstance from 'winston-transport'
 import { config } from '../../../app/config.js'
 
 const loadFreshLogger = async () => {
@@ -26,7 +27,7 @@ describe('logger', () => {
 
   it('Single default log transport enabled', async () => {
     const { logger } = await loadFreshLogger()
-    expect(logger.transports.length).toEqual(1)
+    expect(logger.transports).toHaveLength(1)
     expect(logger.transports[0]).toBeInstanceOf(ConsoleTransportInstance)
   })
 
@@ -47,5 +48,42 @@ describe('logger', () => {
     logger.transports[0].close = jest.fn()
     process.emit('exit')
     expect(logger.transports[0].close).toHaveBeenCalled()
+  })
+
+  describe('level-based JSON formatting guard', () => {
+    let jsonTransformSpy
+
+    beforeEach(() => {
+      // format.json() instances share this prototype transform (see logform/format.js),
+      // so spying here observes every JSON-formatting attempt made via format.json().
+      jsonTransformSpy = jest.spyOn(format.json.Format.prototype, 'transform')
+    })
+
+    it('does not run JSON formatting for a disabled level (debug, with level=info)', async () => {
+      configMockPath.logLevel = 'info'
+      const { logger } = await loadFreshLogger()
+
+      logger.debug('this should be skipped before JSON formatting')
+
+      expect(jsonTransformSpy).not.toHaveBeenCalled()
+    })
+
+    it('runs JSON formatting for an enabled level (info, with level=info)', async () => {
+      configMockPath.logLevel = 'info'
+      const { logger } = await loadFreshLogger()
+
+      logger.info('this should be JSON formatted')
+
+      expect(jsonTransformSpy).toHaveBeenCalled()
+    })
+
+    it('runs JSON formatting for debug once the level is raised to debug', async () => {
+      configMockPath.logLevel = 'debug'
+      const { logger } = await loadFreshLogger()
+
+      logger.debug('this should be JSON formatted')
+
+      expect(jsonTransformSpy).toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
* chore: disabled default winston json formatter

* chore:  remove logging of the response size which used a JSON.stringify which is expensive on large responses and runs in production.

This resolves Jira ticket: [FCPDAL-466]


[FCPDAL-466]: https://eaflood.atlassian.net/browse/FCPDAL-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ