### PR TITLE
fix: removing PII from logs and error responses

### DIFF
--- a/app/auth/authenticate.js
+++ b/app/auth/authenticate.js
@@ -6,6 +6,7 @@ import { config } from '../config.js'
 import { Unauthorized } from '../errors/graphql.js'
 import { DAL_REQUEST_AUTHENTICATION_001 } from '../logger/codes.js'
 import { logger } from '../logger/logger.js'
+import { maskAllButLastFour } from '../logger/utils.js'
 import { sendMetric } from '../logger/sendMetric.js'
 
 export const authGroups = config.get('auth.groups')
@@ -50,7 +51,7 @@ export async function getAuth(request, jwkDatasource) {
           sub: verified.sub,
           tid: verified.tid,
           email: verified.email?.split('@')[1],
-          contactId: verified.contactId,
+          contactId: maskAllButLastFour(verified.contactId),
           relationships: verified.relationships,
           groups: verified.groups,
           roles: verified.roles,

--- a/app/data-sources/rural-payments/RuralPayments.js
+++ b/app/data-sources/rural-payments/RuralPayments.js
@@ -69,6 +69,7 @@ export class RuralPayments extends BaseRESTDataSource {
 
     const internalEmail = this.authContext.internalAuthHeader || this.authContext.serviceAccount
 
+    // Note: these headers won't be logged. See https://portal.cdp-int.defra.cloud/documentation/how-to/logging.md
     if (internalEmail) {
       additionalHeaders.email = internalEmail
     } else {

--- a/app/data-sources/rural-payments/RuralPaymentsCustomer.js
+++ b/app/data-sources/rural-payments/RuralPaymentsCustomer.js
@@ -2,6 +2,7 @@ import { StatusCodes } from 'http-status-codes'
 import { config } from '../../config.js'
 import { NotFound } from '../../errors/graphql.js'
 import { RURALPAYMENTS_API_NOT_FOUND_001 } from '../../logger/codes.js'
+import { maskAllButLastFour } from '../../logger/utils.js'
 import { postPutHeaders } from '../../utils/headers.js'
 import { getSearchOffsetAndLimit } from '../../utils/pagination.js'
 import { RuralPayments } from './RuralPayments.js'
@@ -34,11 +35,14 @@ export class RuralPaymentsCustomer extends RuralPayments {
     })
 
     if (!customerResponse?._data?.length) {
-      this.logger.warn(`#datasource - Rural payments - Customer not found for CRN: ${crn}`, {
-        crn,
-        code: RURALPAYMENTS_API_NOT_FOUND_001,
-        response: { body: customerResponse }
-      })
+      this.logger.warn(
+        `#datasource - Rural payments - Customer not found for CRN: ${maskAllButLastFour(crn)}`,
+        {
+          crn,
+          code: RURALPAYMENTS_API_NOT_FOUND_001,
+          response: { body: customerResponse }
+        }
+      )
       throw new NotFound('Rural payments customer not found')
     }
     return customerResponse._data[0]

--- a/app/graphql/context.js
+++ b/app/graphql/context.js
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken'
 import { getAuth, getRequestingGroup } from '../auth/authenticate.js'
+import { config } from '../config.js'
 import { HitachiPayments } from '../data-sources/hitachi/HitachiPayments.js'
 import { JWKS } from '../data-sources/JWKS.js'
 import { MongoBusiness } from '../data-sources/mongo/Business.js'
@@ -11,7 +12,6 @@ import { Permissions } from '../data-sources/static/permissions.js'
 import { BadRequest } from '../errors/graphql.js'
 import { logger } from '../logger/logger.js'
 import { db } from '../mongo.js'
-import { config } from '../config.js'
 
 export const extractOrgIdFromDefraIdToken = (sbi, token) => {
   const { payload } = jwt.decode(token, { complete: true })

--- a/app/graphql/formatError.js
+++ b/app/graphql/formatError.js
@@ -1,0 +1,18 @@
+// Extensions safe to return to a client: `code` (a machine-readable error category) and
+// `http` (the status Apollo's HTTP integration reads to set the response status). Anything
+// else - e.g. HttpError's raw upstream request/response, which can carry customer PII - must
+// not leave the server.
+const SAFE_EXTENSION_KEYS = new Set(['code', 'http'])
+
+function sanitizeExtensions(extensions = {}) {
+  return Object.fromEntries(
+    Object.entries(extensions).filter(([key]) => SAFE_EXTENSION_KEYS.has(key))
+  )
+}
+
+export function formatError(formattedError, error) {
+  return {
+    ...formattedError,
+    extensions: sanitizeExtensions(formattedError.extensions)
+  }
+}

--- a/app/graphql/formatError.js
+++ b/app/graphql/formatError.js
@@ -10,7 +10,7 @@ function sanitizeExtensions(extensions = {}) {
   )
 }
 
-export function formatError(formattedError, error) {
+export function formatError(formattedError) {
   return {
     ...formattedError,
     extensions: sanitizeExtensions(formattedError.extensions)

--- a/app/graphql/resolvers/customer/common.js
+++ b/app/graphql/resolvers/customer/common.js
@@ -1,4 +1,5 @@
 import { MONGO_DB_ERROR_001 } from '../../../logger/codes.js'
+import { maskAllButLastFour } from '../../../logger/utils.js'
 
 async function upsertPersonIdByCRN(crn, { mongoCustomer, ruralPaymentsCustomer }) {
   const personId = await ruralPaymentsCustomer.getPersonIdByCRN(crn)
@@ -6,7 +7,7 @@ async function upsertPersonIdByCRN(crn, { mongoCustomer, ruralPaymentsCustomer }
   // NOTE: fire-and-forget insertion to avoid slowing down the request, must use .catch for errors
   mongoCustomer.upsertPersonIdByCRN(crn, personId).catch((err) => {
     ruralPaymentsCustomer.logger.warn(
-      `#resolver - Customer - Error storing personId from MongoDB for CRN: ${crn}`,
+      `#resolver - Customer - Error storing personId from MongoDB for CRN: ${maskAllButLastFour(crn)}`,
       {
         crn,
         code: MONGO_DB_ERROR_001,
@@ -28,7 +29,7 @@ export const retrievePersonIdByCRN = async (crn, { mongoCustomer, ruralPaymentsC
     )
   } catch (err) {
     ruralPaymentsCustomer.logger.warn(
-      `#resolver - Customer - Error retrieving personId from MongoDB for CRN: ${crn}`,
+      `#resolver - Customer - Error retrieving personId from MongoDB for CRN: ${maskAllButLastFour(crn)}`,
       {
         crn,
         code: MONGO_DB_ERROR_001,

--- a/app/graphql/server.js
+++ b/app/graphql/server.js
@@ -2,6 +2,7 @@ import { ApolloServer } from '@apollo/server'
 import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled'
 import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
 import { config } from '../config.js'
+import { formatError } from './formatError.js'
 import { createSchema } from './schema.js'
 
 export const schema = await createSchema()
@@ -17,5 +18,6 @@ export const enableApolloLandingPage = () => {
 export const apolloServer = new ApolloServer({
   schema,
   plugins: [enableApolloLandingPage()],
-  introspection: config.get('graphqlDashboardEnabled')
+  introspection: config.get('graphqlDashboardEnabled'),
+  formatError
 })

--- a/app/logger/utils.js
+++ b/app/logger/utils.js
@@ -1,3 +1,8 @@
+export const maskAllButLastFour = (value) => {
+  if (typeof value !== 'string' || value.length <= 4) return value
+  return '*'.repeat(value.length - 4) + value.slice(-4)
+}
+
 const sampleArray = (array, sampleSize = 5) => {
   if (!Array.isArray(array)) {
     return array

--- a/app/logger/winstonFormatters.js
+++ b/app/logger/winstonFormatters.js
@@ -53,6 +53,14 @@ const ALLOWED_KEYS = new Set([
   'searchFieldType'
 ])
 
+// crn/customerReferenceNumber is used as a login username, so we don't want to log the full number for security reasons.
+const MASKED_KEYS = new Set(['crn', 'customerReferenceNumber'])
+
+const maskAllButLastFour = (value) => {
+  if (typeof value !== 'string' || value.length <= 4) return value
+  return '*'.repeat(value.length - 4) + value.slice(-4)
+}
+
 const pickKeysForLogging = (obj) => {
   if (obj == null) return obj
 
@@ -72,7 +80,7 @@ const pickKeysForLogging = (obj) => {
     const value = pickKeysForLogging(obj[key])
 
     if (ALLOWED_KEYS.has(key) || (typeof value === 'object' && value !== null)) {
-      picked[key] = value
+      picked[key] = MASKED_KEYS.has(key) ? maskAllButLastFour(value) : value
     }
   }
 

--- a/app/logger/winstonFormatters.js
+++ b/app/logger/winstonFormatters.js
@@ -44,18 +44,13 @@ const buildEvent = (kind, category, type, created, duration, outcome, reference,
     }
   }
 
-const ALLOWED_KEYS = new Set([
-  'crn',
-  'customerReferenceNumber',
-  'id',
-  'primarySearchPhrase',
-  'sbi',
-  'searchFieldType'
-])
+const ALLOWED_KEYS = new Set(['crn', 'customerReferenceNumber', 'id', 'sbi', 'searchFieldType'])
+
+// primarySearchPhrase is deliberately excluded from ALLOWED_KEYS above: depending on
+// searchFieldType it can hold a crn, customer name or postcode, all of which are PII.
 
 // crn/customerReferenceNumber is used as a login username, so we don't want to log the full number for security reasons.
-// primarySearchPhrase is masked too since it holds the crn when searchFieldType is a customer reference search.
-const MASKED_KEYS = new Set(['crn', 'customerReferenceNumber', 'primarySearchPhrase'])
+const MASKED_KEYS = new Set(['crn', 'customerReferenceNumber'])
 
 const maskAllButLastFour = (value) => {
   if (typeof value !== 'string' || value.length <= 4) return value

--- a/app/logger/winstonFormatters.js
+++ b/app/logger/winstonFormatters.js
@@ -46,8 +46,18 @@ const buildEvent = (kind, category, type, created, duration, outcome, reference,
 
 const ALLOWED_KEYS = new Set(['crn', 'customerReferenceNumber', 'id', 'sbi', 'searchFieldType'])
 
-// primarySearchPhrase is deliberately excluded from ALLOWED_KEYS above: depending on
-// searchFieldType it can hold a crn, customer name or postcode, all of which are PII.
+// primarySearchPhrase is stripped from logs by default: depending on searchFieldType it can hold
+// a crn, customer name or postcode, all of which are PII. It's logged verbatim only when the
+// sibling searchFieldType is one of the values below, which aren't personally identifying on
+// their own.
+const SEARCH_PHRASE_SAFE_FIELD_TYPES = new Set([
+  'SBI',
+  'VENDOR_NUMBER',
+  'TRADER_NUMBER',
+  'PERSONAL_IDENTIFIER'
+])
+
+const SEARCH_PHRASE_MASKED_FIELD_TYPES = new Set(['CUSTOMER_REFERENCE'])
 
 // crn/customerReferenceNumber is used as a login username, so we don't want to log the full number for security reasons.
 const MASKED_KEYS = new Set(['crn', 'customerReferenceNumber'])
@@ -71,12 +81,20 @@ const pickKeysForLogging = (obj) => {
   }
 
   const picked = {}
+  const searchPhraseSafe = SEARCH_PHRASE_SAFE_FIELD_TYPES.has(obj.searchFieldType)
+  const searchPhraseMasked = SEARCH_PHRASE_MASKED_FIELD_TYPES.has(obj.searchFieldType)
 
   for (const key of Object.keys(obj)) {
     const value = pickKeysForLogging(obj[key])
 
-    if (ALLOWED_KEYS.has(key) || (typeof value === 'object' && value !== null)) {
-      picked[key] = MASKED_KEYS.has(key) ? maskAllButLastFour(value) : value
+    const isAllowed =
+      ALLOWED_KEYS.has(key) ||
+      (key === 'primarySearchPhrase' && (searchPhraseSafe || searchPhraseMasked))
+
+    if (isAllowed || (typeof value === 'object' && value !== null)) {
+      const shouldMask =
+        MASKED_KEYS.has(key) || (key === 'primarySearchPhrase' && searchPhraseMasked)
+      picked[key] = shouldMask ? maskAllButLastFour(value) : value
     }
   }
 

--- a/app/logger/winstonFormatters.js
+++ b/app/logger/winstonFormatters.js
@@ -54,7 +54,8 @@ const ALLOWED_KEYS = new Set([
 ])
 
 // crn/customerReferenceNumber is used as a login username, so we don't want to log the full number for security reasons.
-const MASKED_KEYS = new Set(['crn', 'customerReferenceNumber'])
+// primarySearchPhrase is masked too since it holds the crn when searchFieldType is a customer reference search.
+const MASKED_KEYS = new Set(['crn', 'customerReferenceNumber', 'primarySearchPhrase'])
 
 const maskAllButLastFour = (value) => {
   if (typeof value !== 'string' || value.length <= 4) return value

--- a/app/logger/winstonFormatters.js
+++ b/app/logger/winstonFormatters.js
@@ -63,6 +63,22 @@ const SEARCH_PHRASE_MASKED_FIELD_TYPES = new Set(['CUSTOMER_REFERENCE'])
 // crn/customerReferenceNumber is used as a login username, so we don't want to log the full number for security reasons.
 const MASKED_KEYS = new Set(['crn', 'customerReferenceNumber'])
 
+// URL paths that embed PII directly as a path segment, rather than in the body. Each pattern's
+// second capture group is the segment to mask.
+const PII_PATH_PATTERNS = [/(external-auth\/security-answers\/)([^/?]+)/]
+
+const maskPathPII = (pathStr) => {
+  for (const pattern of PII_PATH_PATTERNS) {
+    if (pattern.test(pathStr)) {
+      return pathStr.replace(
+        pattern,
+        (_, prefix, segment) => `${prefix}${maskAllButLastFour(segment)}`
+      )
+    }
+  }
+  return pathStr
+}
+
 const pickKeysForLogging = (obj) => {
   if (obj == null) return obj
 
@@ -102,12 +118,12 @@ const buildUrl = ({ body, path, url }) => {
 
   if (url && path) {
     // Simplest case, both fields supplied, no interpretation needed
-    result.full = url
-    result.path = path
+    result.full = maskPathPII(url.toString())
+    result.path = maskPathPII(path.toString())
   } else {
     const pathToUse = url || path
     if (pathToUse) {
-      const pathStr = pathToUse.toString()
+      const pathStr = maskPathPII(pathToUse.toString())
       if (pathStr.startsWith('http')) {
         result.full = pathStr
         result.path = new URL(pathStr).pathname

--- a/app/logger/winstonFormatters.js
+++ b/app/logger/winstonFormatters.js
@@ -1,4 +1,5 @@
 import { format } from 'winston'
+import { maskAllButLastFour } from './utils.js'
 
 const buildHttpDetails = (request, response, requestTimeMs) => {
   if (!request && !response && !requestTimeMs) return {}
@@ -61,11 +62,6 @@ const SEARCH_PHRASE_MASKED_FIELD_TYPES = new Set(['CUSTOMER_REFERENCE'])
 
 // crn/customerReferenceNumber is used as a login username, so we don't want to log the full number for security reasons.
 const MASKED_KEYS = new Set(['crn', 'customerReferenceNumber'])
-
-const maskAllButLastFour = (value) => {
-  if (typeof value !== 'string' || value.length <= 4) return value
-  return '*'.repeat(value.length - 4) + value.slice(-4)
-}
 
 const pickKeysForLogging = (obj) => {
   if (obj == null) return obj

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.22.0",
+  "version": "2.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.22.0",
+      "version": "2.21.1",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.22.0",
+  "version": "2.21.1",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/unit/auth/authenticate.test.js
+++ b/test/unit/auth/authenticate.test.js
@@ -96,7 +96,7 @@ describe('getAuth', () => {
               '"correlationId":"correlation-id","currentRelationshipId":"relationship-id",' +
               '"sessionId":"session-id","sub":"2d731eb1-6721-4349-9cb2-8fe9b0ab53a2",' +
               '"tid":"2d731eb1-6721-4349-9cb2-8fe9b0ab53a2","email":"defra.gov.uk",' +
-              '"contactId":"contact-id","relationships":["orgId:sbi:company name:"],' +
+              '"contactId":"******t-id","relationships":["orgId:sbi:company name:"],' +
               '"groups":["2d731eb1-6721-4349-9cb2-8fe9b0ab53a2"],' +
               '"roles":["role-id"],"azp":"azp-id"}'
           }
@@ -131,7 +131,7 @@ describe('getAuth', () => {
               '"oid":"2d731eb1-6721-4349-9cb2-8fe9b0ab53a2","serviceId":"service-id",' +
               '"correlationId":"correlation-id","currentRelationshipId":"relationship-id",' +
               '"sessionId":"session-id","sub":"2d731eb1-6721-4349-9cb2-8fe9b0ab53a2",' +
-              '"tid":"2d731eb1-6721-4349-9cb2-8fe9b0ab53a2","contactId":"contact-id",' +
+              '"tid":"2d731eb1-6721-4349-9cb2-8fe9b0ab53a2","contactId":"******t-id",' +
               '"relationships":["orgId:sbi:company name:"],' +
               '"groups":["2d731eb1-6721-4349-9cb2-8fe9b0ab53a2"],' +
               '"roles":["role-id"],"azp":"azp-id"}'

--- a/test/unit/data-sources/rural-payments/rural-payments-customer.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments-customer.test.js
@@ -60,7 +60,7 @@ describe('Rural Payments Customer', () => {
       headers: { 'Content-Type': 'application/json' }
     })
     expect(logger.warn).toHaveBeenCalledWith(
-      '#datasource - Rural payments - Customer not found for CRN: 11111111',
+      '#datasource - Rural payments - Customer not found for CRN: ****1111',
       {
         code: 'RURALPAYMENTS_API_NOT_FOUND_001',
         crn: '11111111',

--- a/test/unit/graphql/formatError.test.js
+++ b/test/unit/graphql/formatError.test.js
@@ -1,0 +1,100 @@
+import { GraphQLError, locatedError } from 'graphql'
+import { formatError } from '../../../app/graphql/formatError.js'
+import { BadRequest, HttpError, NotFound, Unauthorized } from '../../../app/errors/graphql.js'
+
+// Mirrors what graphql-js's execution engine does with a value thrown from a resolver -
+// wraps it in a new, "located" GraphQLError with `originalError` set to the thrown value -
+// then runs it through formatError exactly as Apollo would.
+function formatThrownError(thrownValue) {
+  const error = locatedError(thrownValue, undefined, ['someField'])
+  const formattedError = { message: error.message, path: error.path, extensions: error.extensions }
+
+  return formatError(formattedError, error)
+}
+
+describe('formatError', () => {
+  test('strips the raw upstream response (and any PII in it) from an HttpError', () => {
+    const httpError = new HttpError(400, {
+      extensions: {
+        response: {
+          status: 400,
+          body: { submittedRecord: { email: 'leak@example.com', dateOfBirth: 123456 } }
+        }
+      }
+    })
+
+    const result = formatThrownError(httpError)
+
+    expect(result.message).toBe('Bad Request')
+    expect(result.extensions).toEqual({ code: 'BAD REQUEST', http: { status: 400 } })
+  })
+
+  test('drops any extension not in the safe list, keeping code and http', () => {
+    const notFound = new NotFound('Rural payments customer not found')
+
+    const result = formatThrownError(notFound)
+
+    expect(result.message).toBe('Rural payments customer not found')
+    expect(result.extensions).toEqual({ code: 'NOT FOUND', http: { status: 404 } })
+  })
+
+  test('passes through Unauthorized errors', () => {
+    const unauthorized = new Unauthorized('Unauthorized access')
+
+    const result = formatThrownError(unauthorized)
+
+    expect(result.message).toBe('Unauthorized access')
+    expect(result.extensions).toEqual({ code: 'UNAUTHORIZED', http: { status: 401 } })
+  })
+
+  test('passes through BadRequest errors', () => {
+    const badRequest = new BadRequest('Defra ID token does not contain crn')
+
+    const result = formatThrownError(badRequest)
+
+    expect(result.message).toBe('Defra ID token does not contain crn')
+    expect(result.extensions).toEqual({ code: 'BAD REQUEST', http: { status: 400 } })
+  })
+
+  test('leaves the message untouched, even for unexpected errors', () => {
+    const bug = new TypeError("Cannot read properties of undefined (reading 'crn')")
+
+    const result = formatThrownError(bug)
+
+    expect(result.message).toBe(bug.message)
+    expect(result.extensions).toEqual({})
+  })
+
+  test('passes through ad-hoc GraphQLErrors raised for input validation', () => {
+    const validationError = new GraphQLError('UkAccountNumber must be exactly 8 digits')
+
+    const result = formatThrownError(validationError)
+
+    expect(result.message).toBe('UkAccountNumber must be exactly 8 digits')
+    expect(result.extensions).toEqual({})
+  })
+
+  // Query parse/validation errors never pass through a resolver, so this bypasses
+  // formatThrownError and calls formatError directly, as Apollo would for this case.
+  test('passes through query parse/validation errors, which never have an originalError', () => {
+    const parseError = new GraphQLError('Cannot query field "bogus" on type "Query".', {
+      extensions: { code: 'GRAPHQL_VALIDATION_FAILED' }
+    })
+    const formattedError = {
+      message: parseError.message,
+      path: parseError.path,
+      extensions: parseError.extensions
+    }
+
+    const result = formatError(formattedError, parseError)
+
+    expect(result.message).toBe('Cannot query field "bogus" on type "Query".')
+    expect(result.extensions).toEqual({ code: 'GRAPHQL_VALIDATION_FAILED' })
+  })
+
+  test('defaults to an empty extensions object when none are present', () => {
+    const result = formatError({ message: 'plain error' })
+
+    expect(result.extensions).toEqual({})
+  })
+})

--- a/test/unit/graphql/server.test.js
+++ b/test/unit/graphql/server.test.js
@@ -47,7 +47,8 @@ describe('GraphQL Dashboard test with mocks', () => {
     expect(mockApolloServer).toHaveBeenCalledWith({
       schema: 'mockCreateSchemaRV',
       plugins: [mockApolloPluginDisabled()],
-      introspection: false
+      introspection: false,
+      formatError: expect.any(Function)
     })
   })
 
@@ -69,7 +70,8 @@ describe('GraphQL Dashboard test with mocks', () => {
     expect(mockApolloServer).toHaveBeenCalledWith({
       schema: 'mockCreateSchemaRV',
       plugins: [mockApolloPluginLandingPage()],
-      introspection: true
+      introspection: true,
+      formatError: expect.any(Function)
     })
   })
 })

--- a/test/unit/logger/utils.test.js
+++ b/test/unit/logger/utils.test.js
@@ -1,4 +1,4 @@
-import { sampleResponse } from '../../../app/logger/utils.js'
+import { maskAllButLastFour, sampleResponse } from '../../../app/logger/utils.js'
 
 describe('sampleResponse', () => {
   it('should return null for null input', () => {
@@ -64,5 +64,30 @@ describe('sampleResponse', () => {
     const inputCopy = JSON.parse(JSON.stringify(input))
     sampleResponse(input)
     expect(input).toEqual(inputCopy)
+  })
+})
+
+describe('maskAllButLastFour', () => {
+  it('masks all but the last four characters of a string', () => {
+    expect(maskAllButLastFour('1234567890')).toBe('******7890')
+  })
+
+  it('leaves a four character string unmasked', () => {
+    expect(maskAllButLastFour('1234')).toBe('1234')
+  })
+
+  it('leaves a string shorter than four characters unmasked', () => {
+    expect(maskAllButLastFour('123')).toBe('123')
+  })
+
+  it('returns an empty string unchanged', () => {
+    expect(maskAllButLastFour('')).toBe('')
+  })
+
+  it('returns non-string values unchanged', () => {
+    expect(maskAllButLastFour(1234567890)).toBe(1234567890)
+    expect(maskAllButLastFour(null)).toBeNull()
+    expect(maskAllButLastFour(undefined)).toBeUndefined()
+    expect(maskAllButLastFour({ crn: '1234567890' })).toEqual({ crn: '1234567890' })
   })
 })

--- a/test/unit/logger/winstonFormatters.test.js
+++ b/test/unit/logger/winstonFormatters.test.js
@@ -112,7 +112,7 @@ describe('winstonFormatters', () => {
         url: {
           full: 'http://localhost/path',
           path: 'http://localhost/path',
-          query: '{"searchFieldType":"SBI","primarySearchPhrase":"107183280"}'
+          query: '{"searchFieldType":"SBI","primarySearchPhrase":"*****3280"}'
         }
       })
     })
@@ -147,7 +147,7 @@ describe('winstonFormatters', () => {
       url: {
         full: 'http://localhost/path',
         path: 'http://localhost/path',
-        query: '{"searchFieldType":"SBI","primarySearchPhrase":"107183280"}'
+        query: '{"searchFieldType":"SBI","primarySearchPhrase":"*****3280"}'
       }
     })
   })
@@ -234,7 +234,7 @@ describe('winstonFormatters', () => {
         crn: '**N001',
         customerReferenceNumber: '**N002',
         sbi: '123456789',
-        primarySearchPhrase: 'john doe',
+        primarySearchPhrase: '**** doe',
         searchFieldType: 'name',
         id: 'user-123',
         nested: { crn: '******-crn' },
@@ -245,12 +245,13 @@ describe('winstonFormatters', () => {
       })
     })
 
-    it('masks crn and customerReferenceNumber, keeping only the last 4 characters', () => {
+    it('masks crn, customerReferenceNumber and primarySearchPhrase, keeping only the last 4 characters', () => {
       const result = cdpSchemaTranslator().transform({
         request: {
           body: {
             crn: '1234567890',
             customerReferenceNumber: '9876543210',
+            primarySearchPhrase: '1234567890',
             shortCrn: 'ab', // key not masked, but also under 4 chars — included verbatim
             nested: { crn: '5555' } // exactly 4 chars, nothing to mask
           }
@@ -260,6 +261,7 @@ describe('winstonFormatters', () => {
       expect(JSON.parse(result.url.query)).toEqual({
         crn: '******7890',
         customerReferenceNumber: '******3210',
+        primarySearchPhrase: '******7890',
         nested: { crn: '5555' }
       })
     })
@@ -278,7 +280,7 @@ describe('winstonFormatters', () => {
 
       expect(JSON.parse(result.url.query)).toEqual({
         sbi: '987654321',
-        primarySearchPhrase: 'jane doe'
+        primarySearchPhrase: '**** doe'
       })
     })
   })

--- a/test/unit/logger/winstonFormatters.test.js
+++ b/test/unit/logger/winstonFormatters.test.js
@@ -112,7 +112,7 @@ describe('winstonFormatters', () => {
         url: {
           full: 'http://localhost/path',
           path: 'http://localhost/path',
-          query: '{"searchFieldType":"SBI"}'
+          query: '{"searchFieldType":"SBI","primarySearchPhrase":"107183280"}'
         }
       })
     })
@@ -147,7 +147,7 @@ describe('winstonFormatters', () => {
       url: {
         full: 'http://localhost/path',
         path: 'http://localhost/path',
-        query: '{"searchFieldType":"SBI"}'
+        query: '{"searchFieldType":"SBI","primarySearchPhrase":"107183280"}'
       }
     })
   })
@@ -294,6 +294,50 @@ describe('winstonFormatters', () => {
 
       expect(JSON.parse(result.url.query)).toEqual({
         sbi: '987654321'
+      })
+    })
+
+    describe('primarySearchPhrase, based on sibling searchFieldType', () => {
+      it.each(['SBI', 'VENDOR_NUMBER', 'TRADER_NUMBER', 'PERSONAL_IDENTIFIER'])(
+        'logs primarySearchPhrase when searchFieldType is %s',
+        (searchFieldType) => {
+          const result = cdpSchemaTranslator().transform({
+            request: {
+              body: { searchFieldType, primarySearchPhrase: 'ABC123' }
+            }
+          })
+
+          expect(JSON.parse(result.url.query)).toEqual({
+            searchFieldType,
+            primarySearchPhrase: 'ABC123'
+          })
+        }
+      )
+
+      it.each(['BUSINESS_NAME', 'BUSINESS_POSTCODE', 'CUSTOMER_NAME', 'CUSTOMER_POSTCODE', 'CRN'])(
+        'excludes primarySearchPhrase when searchFieldType is %s',
+        (searchFieldType) => {
+          const result = cdpSchemaTranslator().transform({
+            request: {
+              body: { searchFieldType, primarySearchPhrase: 'jane doe' }
+            }
+          })
+
+          expect(JSON.parse(result.url.query)).toEqual({ searchFieldType })
+        }
+      )
+
+      it('masks primarySearchPhrase to the last 4 digits when searchFieldType is CUSTOMER_REFERENCE (the wire-level CRN search type)', () => {
+        const result = cdpSchemaTranslator().transform({
+          request: {
+            body: { searchFieldType: 'CUSTOMER_REFERENCE', primarySearchPhrase: '1234567890' }
+          }
+        })
+
+        expect(JSON.parse(result.url.query)).toEqual({
+          searchFieldType: 'CUSTOMER_REFERENCE',
+          primarySearchPhrase: '******7890'
+        })
       })
     })
   })

--- a/test/unit/logger/winstonFormatters.test.js
+++ b/test/unit/logger/winstonFormatters.test.js
@@ -231,17 +231,36 @@ describe('winstonFormatters', () => {
       })
 
       expect(JSON.parse(result.url.query)).toEqual({
-        crn: 'CRN001',
-        customerReferenceNumber: 'CRN002',
+        crn: '**N001',
+        customerReferenceNumber: '**N002',
         sbi: '123456789',
         primarySearchPhrase: 'john doe',
         searchFieldType: 'name',
         id: 'user-123',
-        nested: { crn: 'nested-crn' },
+        nested: { crn: '******-crn' },
         array: [{ id: 'allowed' }],
         other: {
           crn: null
         }
+      })
+    })
+
+    it('masks crn and customerReferenceNumber, keeping only the last 4 characters', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: {
+          body: {
+            crn: '1234567890',
+            customerReferenceNumber: '9876543210',
+            shortCrn: 'ab', // key not masked, but also under 4 chars — included verbatim
+            nested: { crn: '5555' } // exactly 4 chars, nothing to mask
+          }
+        }
+      })
+
+      expect(JSON.parse(result.url.query)).toEqual({
+        crn: '******7890',
+        customerReferenceNumber: '******3210',
+        nested: { crn: '5555' }
       })
     })
 

--- a/test/unit/logger/winstonFormatters.test.js
+++ b/test/unit/logger/winstonFormatters.test.js
@@ -112,7 +112,7 @@ describe('winstonFormatters', () => {
         url: {
           full: 'http://localhost/path',
           path: 'http://localhost/path',
-          query: '{"searchFieldType":"SBI","primarySearchPhrase":"*****3280"}'
+          query: '{"searchFieldType":"SBI"}'
         }
       })
     })
@@ -147,7 +147,7 @@ describe('winstonFormatters', () => {
       url: {
         full: 'http://localhost/path',
         path: 'http://localhost/path',
-        query: '{"searchFieldType":"SBI","primarySearchPhrase":"*****3280"}'
+        query: '{"searchFieldType":"SBI"}'
       }
     })
   })
@@ -234,7 +234,6 @@ describe('winstonFormatters', () => {
         crn: '**N001',
         customerReferenceNumber: '**N002',
         sbi: '123456789',
-        primarySearchPhrase: '**** doe',
         searchFieldType: 'name',
         id: 'user-123',
         nested: { crn: '******-crn' },
@@ -245,13 +244,12 @@ describe('winstonFormatters', () => {
       })
     })
 
-    it('masks crn, customerReferenceNumber and primarySearchPhrase, keeping only the last 4 characters', () => {
+    it('masks crn and customerReferenceNumber, keeping only the last 4 characters', () => {
       const result = cdpSchemaTranslator().transform({
         request: {
           body: {
             crn: '1234567890',
             customerReferenceNumber: '9876543210',
-            primarySearchPhrase: '1234567890',
             shortCrn: 'ab', // key not masked, but also under 4 chars — included verbatim
             nested: { crn: '5555' } // exactly 4 chars, nothing to mask
           }
@@ -261,8 +259,24 @@ describe('winstonFormatters', () => {
       expect(JSON.parse(result.url.query)).toEqual({
         crn: '******7890',
         customerReferenceNumber: '******3210',
-        primarySearchPhrase: '******7890',
         nested: { crn: '5555' }
+      })
+    })
+
+    it('excludes primarySearchPhrase entirely, since it may hold a crn, name or postcode', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: {
+          body: {
+            sbi: '987654321',
+            primarySearchPhrase: 'jane doe',
+            allowed: 'no',
+            disallowed: 'yes'
+          }
+        }
+      })
+
+      expect(JSON.parse(result.url.query)).toEqual({
+        sbi: '987654321'
       })
     })
 
@@ -279,8 +293,7 @@ describe('winstonFormatters', () => {
       })
 
       expect(JSON.parse(result.url.query)).toEqual({
-        sbi: '987654321',
-        primarySearchPhrase: '**** doe'
+        sbi: '987654321'
       })
     })
   })

--- a/test/unit/logger/winstonFormatters.test.js
+++ b/test/unit/logger/winstonFormatters.test.js
@@ -431,5 +431,45 @@ describe('winstonFormatters', () => {
       })
       expect(result.url).toEqual({ full: '/organisation/123', path: '/organisation/123' })
     })
+
+    it('masks the crn segment of an external-auth security-answers path', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: { path: '/external-auth/security-answers/1234567890' }
+      })
+      expect(result.url).toEqual({
+        full: '/external-auth/security-answers/******7890',
+        path: '/external-auth/security-answers/******7890'
+      })
+    })
+
+    it('masks the crn segment of a full external-auth security-answers URL', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: { path: 'https://api.example.com/external-auth/security-answers/1234567890' }
+      })
+      expect(result.url).toEqual({
+        full: 'https://api.example.com/external-auth/security-answers/******7890',
+        path: '/external-auth/security-answers/******7890'
+      })
+    })
+
+    it('masks the crn segment when both url and path are supplied', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: {
+          url: 'https://api.example.com/external-auth/security-answers/1234567890',
+          path: '/external-auth/security-answers/1234567890'
+        }
+      })
+      expect(result.url).toEqual({
+        full: 'https://api.example.com/external-auth/security-answers/******7890',
+        path: '/external-auth/security-answers/******7890'
+      })
+    })
+
+    it('does not affect paths that are not in the PII path pattern list', () => {
+      const result = cdpSchemaTranslator().transform({
+        request: { path: '/organisation/123' }
+      })
+      expect(result.url).toEqual({ full: '/organisation/123', path: '/organisation/123' })
+    })
   })
 })

--- a/test/unit/resolvers/customer/common.test.js
+++ b/test/unit/resolvers/customer/common.test.js
@@ -53,7 +53,7 @@ describe('retrievePersonIdByCRN', () => {
 
     expect(dataSources.mongoCustomer.findPersonIdByCRN).toHaveBeenCalledWith(crn)
     expect(dataSources.ruralPaymentsCustomer.logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Error retrieving personId from MongoDB for CRN: 1234567890'),
+      expect.stringContaining('Error retrieving personId from MongoDB for CRN: ******7890'),
       expect.objectContaining({
         crn: crn,
         error: mongoError


### PR DESCRIPTION
* fix: masking all but last 4 digits of crn/customerReferenceNumber in logs as classed as PII

* fix: only log primarySearchPhrase  for specific searchFieldType values

* fix: exclude upstream request and responses from graphql error responses

Description of changes...

This fixes/resolves/relates to Jira ticket: [FCPDAL-286]


[FCPDAL-286]: https://eaflood.atlassian.net/browse/FCPDAL-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ