### PR TITLE
Fix/negative request times

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -51,7 +51,9 @@ server.ext({
 })
 
 server.events.on('response', function (request) {
-  // request.info.responded can be 0 if not responded yet which produces a negative duration in the logs
+  // @hapi/hapi leaves request.info.responded at its initial value of 0 when the
+  // response is never fully written (e.g. the client disconnects mid-response).
+  // This produces a negative duration in the logs
   const requestTimeMs =
     request.info.responded === 0 ? null : request.info.responded - request.info.received
 

--- a/app/server.js
+++ b/app/server.js
@@ -51,13 +51,17 @@ server.ext({
 })
 
 server.events.on('response', function (request) {
-  const requestTimeMs = request.info.responded - request.info.received
+  // request.info.responded can be 0 if not responded yet which produces a negative duration in the logs
+  const requestTimeMs =
+    request.info.responded === 0 ? null : request.info.responded - request.info.received
 
   if (request.path !== healthRoute.path) {
     // Only send metrics and logs for non-health check paths
-    sendMetric('RequestTime', requestTimeMs, Unit.Milliseconds, {
-      code: DAL_APPLICATION_REQUEST_001
-    })
+    if (requestTimeMs !== null) {
+      sendMetric('RequestTime', requestTimeMs, Unit.Milliseconds, {
+        code: DAL_APPLICATION_REQUEST_001
+      })
+    }
 
     logger.info('FCP - Access log', {
       type: 'http',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.25.0",
+      "version": "2.25.1",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/unit/integration/narrow/app/server.test.js
+++ b/test/unit/integration/narrow/app/server.test.js
@@ -143,5 +143,31 @@ describe('Server config and startup', () => {
       expect(mockSendMetric.sendMetric).not.toHaveBeenCalled()
       expect(mockLogger.logger.info).not.toHaveBeenCalled()
     })
+
+    test('response event does not log a negative requestTimeMs when the client aborted the response', () => {
+      // @hapi/hapi leaves request.info.responded at its initial value of 0 when the
+      // response is never fully written (e.g. the client disconnects mid-response).
+      const abortedRequest = {
+        path: '/non-health',
+        transactionId: 'test-transaction-id',
+        traceId: 'test-trace-id',
+        method: 'get',
+        params: {},
+        payload: null,
+        body: null,
+        headers: {},
+        requestingService: undefined,
+        info: { received: Date.now(), responded: 0, remoteAddress: '127.0.0.1' },
+        response: { statusCode: 499, headers: {}, source: null }
+      }
+
+      server.events.emit('response', abortedRequest)
+
+      expect(mockSendMetric.sendMetric).not.toHaveBeenCalled()
+      expect(mockLogger.logger.info).toHaveBeenCalledWith(
+        'FCP - Access log',
+        expect.objectContaining({ requestTimeMs: null })
+      )
+    })
   })
 })


### PR DESCRIPTION
Prevent logging negative durations on requests that have not responded

This relates to Jira ticket: [FCPDAL-73]


[FCPDAL-73]: https://eaflood.atlassian.net/browse/FCPDAL-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ