### PR TITLE
Feat/validate email on update

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -40,5 +40,5 @@ HITACHI_DISABLE_AUTH=true
 
 
 # Currently set to the existing level of coverage. Should increase these thresholds as we increase coverage.
-SCHEMA_FIELD_COVERAGE_THRESHOLD=78
-SCHEMA_TYPE_COVERAGE_THRESHOLD=76
+SCHEMA_FIELD_COVERAGE_THRESHOLD=81
+SCHEMA_TYPE_COVERAGE_THRESHOLD=83

--- a/app/errors/graphql.js
+++ b/app/errors/graphql.js
@@ -23,7 +23,8 @@ export class BadRequest extends GraphQLError {
   constructor(message, options) {
     super(message, options)
 
-    this.extensions.code = StatusCodes.getStatusText(StatusCodes.BAD_REQUEST).toUpperCase()
+    this.extensions.code =
+      options?.extensions?.code ?? StatusCodes.getStatusText(StatusCodes.BAD_REQUEST).toUpperCase()
     this.extensions.http = { status: StatusCodes.BAD_REQUEST }
   }
 }

--- a/app/graphql/resolvers/customer/mutation.js
+++ b/app/graphql/resolvers/customer/mutation.js
@@ -5,6 +5,21 @@ async function updateCustomerResolver(_, { input }, { dataSources }) {
 
   const person = await dataSources.ruralPaymentsCustomer.getPersonByPersonId(personId)
 
+  const isEmailChanging =
+    input.email && input.email.address?.toLowerCase() !== person.email?.toLowerCase()
+
+  if (isEmailChanging) {
+    const { emailDuplicated } = await dataSources.ruralPaymentsCustomer.validateEmail(
+      input.email.address
+    )
+    if (emailDuplicated) {
+      return {
+        success: false,
+        emailDuplicated: true
+      }
+    }
+  }
+
   await dataSources.ruralPaymentsCustomer.updatePersonDetails(
     personId,
     transformCustomerUpdateInputToPersonUpdate(person, input)

--- a/app/graphql/resolvers/customer/mutation.js
+++ b/app/graphql/resolvers/customer/mutation.js
@@ -1,4 +1,5 @@
 import { transformCustomerUpdateInputToPersonUpdate } from '../../../transformers/rural-payments/customer.js'
+import { BadRequest } from '../../../errors/graphql.js'
 
 async function updateCustomerResolver(_, { input }, { dataSources }) {
   const personId = await dataSources.ruralPaymentsCustomer.getPersonIdByCRN(input.crn)
@@ -13,10 +14,9 @@ async function updateCustomerResolver(_, { input }, { dataSources }) {
       input.email.address
     )
     if (emailDuplicated) {
-      return {
-        success: false,
-        emailDuplicated: true
-      }
+      throw new BadRequest('Email address is already in use by another customer', {
+        extensions: { code: 'EMAIL_ALREADY_REGISTERED' }
+      })
     }
   }
 

--- a/app/graphql/types/common.gql
+++ b/app/graphql/types/common.gql
@@ -11,7 +11,11 @@ type Phone {
   landline: String
 }
 
-"Represents data about the email address of a customer or business"
+"""
+Represents data about the email address of a customer or business.
+
+This address should not be used for correspondence unless `validated` is `true`.
+"""
 type Email {
   """
   Email address of the customer or business
@@ -19,7 +23,8 @@ type Email {
   address: String
 
   """
-  Validated status of the email address
+  Whether the email address has been validated. Only use `address` for
+  correspondence when this is `true`.
   """
   validated: Boolean
 }

--- a/app/graphql/types/customer/mutation.gql
+++ b/app/graphql/types/customer/mutation.gql
@@ -6,6 +6,11 @@ extend type Mutation {
   """
   Updates the customer's email address. As a result, the email address is
   marked as not validated.
+
+  Error codes:
+  - `NOT FOUND`: No customer exists for the given CRN.
+  - `EMAIL_ALREADY_REGISTERED`: The email address is already in use by
+    another customer. The customer record is left unchanged.
   """
   updateCustomerEmail(input: UpdateCustomerEmailInput!): UpdateCustomerResponse
     @auth(requires: [SINGLE_FRONT_DOOR])
@@ -15,6 +20,15 @@ extend type Mutation {
     @auth(requires: [SINGLE_FRONT_DOOR])
   updateCustomerDoNotContact(input: UpdateCustomerDoNotContactInput!): UpdateCustomerResponse
     @auth(requires: [SINGLE_FRONT_DOOR])
+  """
+  Updates a customer. If the email address is updated, it is
+  marked as not validated.
+
+  Error codes:
+  - `NOT FOUND`: No customer exists for the given CRN.
+  - `EMAIL_ALREADY_REGISTERED`: The email address is already in use by
+    another customer. The customer record is left unchanged.
+  """
   updateCustomerAllFields(input: UpdateCustomerAllFieldsInput!): UpdateCustomerResponse
     @auth(requires: [SINGLE_FRONT_DOOR])
 }

--- a/app/graphql/types/customer/mutation.gql
+++ b/app/graphql/types/customer/mutation.gql
@@ -153,5 +153,10 @@ input UpdateCustomerAllFieldsInput {
 
 type UpdateCustomerResponse {
   success: Boolean
+  """
+  Set to true when the update was rejected because the email address is
+  already in use by another customer. The customer record is left unchanged.
+  """
+  emailDuplicated: Boolean
   customer: Customer
 }

--- a/app/graphql/types/customer/mutation.gql
+++ b/app/graphql/types/customer/mutation.gql
@@ -3,6 +3,10 @@ extend type Mutation {
     @auth(requires: [SINGLE_FRONT_DOOR])
   updateCustomerDateOfBirth(input: UpdateCustomerDateOfBirthInput!): UpdateCustomerResponse
     @auth(requires: [SINGLE_FRONT_DOOR])
+  """
+  Updates the customer's email address. As a result, the email address is
+  marked as not validated.
+  """
   updateCustomerEmail(input: UpdateCustomerEmailInput!): UpdateCustomerResponse
     @auth(requires: [SINGLE_FRONT_DOOR])
   updateCustomerName(input: UpdateCustomerNameInput!): UpdateCustomerResponse
@@ -153,10 +157,5 @@ input UpdateCustomerAllFieldsInput {
 
 type UpdateCustomerResponse {
   success: Boolean
-  """
-  Set to true when the update was rejected because the email address is
-  already in use by another customer. The customer record is left unchanged.
-  """
-  emailDuplicated: Boolean
   customer: Customer
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "eslint": "^8.57.1",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jest": "^28.9.0",
-        "graphql-request": "^7.3.1",
+        "graphql-request": "^7.4.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
         "nock": "^14.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.26.0",
+      "version": "2.27.0",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jest": "^28.9.0",
-    "graphql-request": "^7.3.1",
+    "graphql-request": "^7.4.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "nock": "^14.0.2",

--- a/test/acceptance/Dockerfile
+++ b/test/acceptance/Dockerfile
@@ -4,5 +4,5 @@ USER node
 
 WORKDIR /app
 RUN npm install --ignore-scripts --save-exact --min-release-age=7 \
-     graphql-request@7.3.1 jest@29.7.0 jsonwebtoken@9.0.2 \
+     graphql-request@7.4.0 jest@29.7.0 jsonwebtoken@9.0.2 \
  && npm pkg set type=module "scripts.test"="NODE_OPTIONS=--experimental-vm-modules jest"

--- a/test/acceptance/customer/mutations.test.js
+++ b/test/acceptance/customer/mutations.test.js
@@ -301,6 +301,84 @@ describe('Customer Mutations - as an internal user', () => {
   })
 })
 
+describe('Customer Mutations - duplicate email handling', () => {
+  const crn = '9000000000'
+  const headers = { email: 'some-email' }
+  const duplicateEmail = 'skeleton@the-closet.net' // known duplicate, see validateCustomerEmail acceptance tests
+
+  const setEmailMutation = gql`
+    mutation SetEmail($input: UpdateCustomerEmailInput!) {
+      updateCustomerEmail(input: $input) {
+        success
+        emailDuplicated
+      }
+    }
+  `
+
+  const setAllFieldsEmailMutation = gql`
+    mutation SetAllFieldsEmail($input: UpdateCustomerAllFieldsInput!) {
+      updateCustomerAllFields(input: $input) {
+        success
+        emailDuplicated
+      }
+    }
+  `
+
+  const customerEmailQuery = gql`
+    query CustomerEmail($crn: ID!) {
+      customer(crn: $crn) {
+        info {
+          email {
+            address
+          }
+        }
+      }
+    }
+  `
+
+  it('should reject updateCustomerEmail when the email address is a known duplicate, leaving the customer unchanged', async () => {
+    const client = new GraphQLClient(targetURL)
+
+    const setup = await client.request(
+      setEmailMutation,
+      { input: { crn, email: { address: 'not-a-duplicate@example.com' } } },
+      headers
+    )
+    expect(setup.updateCustomerEmail).toEqual({ success: true, emailDuplicated: null })
+
+    const response = await client.request(
+      setEmailMutation,
+      { input: { crn, email: { address: duplicateEmail } } },
+      headers
+    )
+    expect(response.updateCustomerEmail).toEqual({ success: false, emailDuplicated: true })
+
+    const check = await client.request(customerEmailQuery, { crn }, headers)
+    expect(check.customer.info.email.address).toBe('not-a-duplicate@example.com')
+  })
+
+  it('should reject updateCustomerAllFields when the email address is a known duplicate, leaving the customer unchanged', async () => {
+    const client = new GraphQLClient(targetURL)
+
+    const setup = await client.request(
+      setAllFieldsEmailMutation,
+      { input: { crn, email: { address: 'still-not-a-duplicate@example.com' } } },
+      headers
+    )
+    expect(setup.updateCustomerAllFields).toEqual({ success: true, emailDuplicated: null })
+
+    const response = await client.request(
+      setAllFieldsEmailMutation,
+      { input: { crn, email: { address: duplicateEmail } } },
+      headers
+    )
+    expect(response.updateCustomerAllFields).toEqual({ success: false, emailDuplicated: true })
+
+    const check = await client.request(customerEmailQuery, { crn }, headers)
+    expect(check.customer.info.email.address).toBe('still-not-a-duplicate@example.com')
+  })
+})
+
 describe('Customer Mutations - as an external user', () => {
   const tokenValue = jwt.sign(
     {

--- a/test/acceptance/customer/mutations.test.js
+++ b/test/acceptance/customer/mutations.test.js
@@ -310,7 +310,6 @@ describe('Customer Mutations - duplicate email handling', () => {
     mutation SetEmail($input: UpdateCustomerEmailInput!) {
       updateCustomerEmail(input: $input) {
         success
-        emailDuplicated
       }
     }
   `
@@ -319,7 +318,6 @@ describe('Customer Mutations - duplicate email handling', () => {
     mutation SetAllFieldsEmail($input: UpdateCustomerAllFieldsInput!) {
       updateCustomerAllFields(input: $input) {
         success
-        emailDuplicated
       }
     }
   `
@@ -344,14 +342,24 @@ describe('Customer Mutations - duplicate email handling', () => {
       { input: { crn, email: { address: 'not-a-duplicate@example.com' } } },
       headers
     )
-    expect(setup.updateCustomerEmail).toEqual({ success: true, emailDuplicated: null })
+    expect(setup.updateCustomerEmail).toEqual({ success: true })
 
-    const response = await client.request(
-      setEmailMutation,
-      { input: { crn, email: { address: duplicateEmail } } },
-      headers
-    )
-    expect(response.updateCustomerEmail).toEqual({ success: false, emailDuplicated: true })
+    await expect(
+      client.request(
+        setEmailMutation,
+        { input: { crn, email: { address: duplicateEmail } } },
+        headers
+      )
+    ).rejects.toMatchObject({
+      response: {
+        errors: [
+          expect.objectContaining({
+            message: 'Email address is already in use by another customer',
+            extensions: expect.objectContaining({ code: 'EMAIL_ALREADY_REGISTERED' })
+          })
+        ]
+      }
+    })
 
     const check = await client.request(customerEmailQuery, { crn }, headers)
     expect(check.customer.info.email.address).toBe('not-a-duplicate@example.com')
@@ -365,14 +373,24 @@ describe('Customer Mutations - duplicate email handling', () => {
       { input: { crn, email: { address: 'still-not-a-duplicate@example.com' } } },
       headers
     )
-    expect(setup.updateCustomerAllFields).toEqual({ success: true, emailDuplicated: null })
+    expect(setup.updateCustomerAllFields).toEqual({ success: true })
 
-    const response = await client.request(
-      setAllFieldsEmailMutation,
-      { input: { crn, email: { address: duplicateEmail } } },
-      headers
-    )
-    expect(response.updateCustomerAllFields).toEqual({ success: false, emailDuplicated: true })
+    await expect(
+      client.request(
+        setAllFieldsEmailMutation,
+        { input: { crn, email: { address: duplicateEmail } } },
+        headers
+      )
+    ).rejects.toMatchObject({
+      response: {
+        errors: [
+          expect.objectContaining({
+            message: 'Email address is already in use by another customer',
+            extensions: expect.objectContaining({ code: 'EMAIL_ALREADY_REGISTERED' })
+          })
+        ]
+      }
+    })
 
     const check = await client.request(customerEmailQuery, { crn }, headers)
     expect(check.customer.info.email.address).toBe('still-not-a-duplicate@example.com')

--- a/test/graphql/mutation/customer.test.js
+++ b/test/graphql/mutation/customer.test.js
@@ -251,6 +251,10 @@ describe('customer mutations', () => {
       email: 'newEmail'
     })
 
+    nock(config.get('kits.internal.gatewayUrl'))
+      .get('/person/newEmail/validateEmail')
+      .reply(200, { _data: { emailDuplicated: false } })
+
     const result = await makeTestQuery(`#graphql
       mutation {
         updateCustomerEmail(input: { crn: "1234567890", email: { address: "newEmail" } }) {

--- a/test/unit/errors/graphql.test.js
+++ b/test/unit/errors/graphql.test.js
@@ -30,6 +30,16 @@ describe('Custom GraphQL HTTP Errors', () => {
     expect(err.extensions.http).toEqual({ status: StatusCodes.BAD_REQUEST })
   })
 
+  test('BadRequest allows a custom code to be provided via options', () => {
+    const err = new BadRequest('Email address is already in use by another customer', {
+      extensions: { code: 'EMAIL_ALREADY_REGISTERED' }
+    })
+
+    expect(err).toBeInstanceOf(GraphQLError)
+    expect(err.extensions.code).toBe('EMAIL_ALREADY_REGISTERED')
+    expect(err.extensions.http).toEqual({ status: StatusCodes.BAD_REQUEST })
+  })
+
   test('HttpError sets code and http status dynamically', () => {
     const status = StatusCodes.FORBIDDEN
     const err = new HttpError(status)

--- a/test/unit/resolvers/customer/customer-mutation.test.js
+++ b/test/unit/resolvers/customer/customer-mutation.test.js
@@ -42,7 +42,8 @@ describe('Customer Mutations', () => {
       ruralPaymentsCustomer: {
         getPersonIdByCRN: jest.fn(),
         getPersonByPersonId: jest.fn(),
-        updatePersonDetails: jest.fn()
+        updatePersonDetails: jest.fn(),
+        validateEmail: jest.fn()
       }
     }
   })
@@ -130,4 +131,101 @@ describe('Customer Mutations', () => {
       })
     })
   })
+
+  describe.each(['updateCustomerEmail', 'updateCustomerAllFields'])(
+    '%s email duplicate check',
+    (mutationName) => {
+      beforeEach(() => {
+        mockDataSources.ruralPaymentsCustomer.getPersonIdByCRN.mockResolvedValue('currentId')
+        mockDataSources.ruralPaymentsCustomer.getPersonByPersonId.mockResolvedValue(mockPerson)
+      })
+
+      test('should call validateEmail with the new email address', async () => {
+        const input = { crn: 'crn', email: { address: 'new@example.com' } }
+
+        mockDataSources.ruralPaymentsCustomer.validateEmail.mockResolvedValue({
+          emailDuplicated: false
+        })
+
+        await Mutation[mutationName](null, { input }, { dataSources: mockDataSources })
+
+        expect(mockDataSources.ruralPaymentsCustomer.validateEmail).toHaveBeenCalledWith(
+          'new@example.com'
+        )
+      })
+
+      test('should not update the customer and should return emailDuplicated when the email is a duplicate', async () => {
+        const input = { crn: 'crn', email: { address: 'new@example.com' } }
+
+        mockDataSources.ruralPaymentsCustomer.validateEmail.mockResolvedValue({
+          emailDuplicated: true
+        })
+
+        const result = await Mutation[mutationName](
+          null,
+          { input },
+          { dataSources: mockDataSources }
+        )
+
+        expect(result).toEqual({
+          success: false,
+          emailDuplicated: true
+        })
+        expect(mockDataSources.ruralPaymentsCustomer.updatePersonDetails).not.toHaveBeenCalled()
+      })
+
+      test('should update the customer when the email is not a duplicate', async () => {
+        const input = { crn: 'crn', email: { address: 'new@example.com' } }
+
+        mockDataSources.ruralPaymentsCustomer.validateEmail.mockResolvedValue({
+          emailDuplicated: false
+        })
+
+        const result = await Mutation[mutationName](
+          null,
+          { input },
+          { dataSources: mockDataSources }
+        )
+
+        expect(mockDataSources.ruralPaymentsCustomer.updatePersonDetails).toHaveBeenCalled()
+        expect(result).toEqual({
+          success: true,
+          customer: { personId: 'currentId' }
+        })
+      })
+
+      test('should not call validateEmail when the input has no email', async () => {
+        const input = { crn: 'crn', first: 'newFirstName' }
+
+        await Mutation[mutationName](null, { input }, { dataSources: mockDataSources })
+
+        expect(mockDataSources.ruralPaymentsCustomer.validateEmail).not.toHaveBeenCalled()
+      })
+
+      test("should not call validateEmail when the email is unchanged from the customer's current email", async () => {
+        const input = { crn: 'crn', email: { address: mockPerson.email } }
+
+        const result = await Mutation[mutationName](
+          null,
+          { input },
+          { dataSources: mockDataSources }
+        )
+
+        expect(mockDataSources.ruralPaymentsCustomer.validateEmail).not.toHaveBeenCalled()
+        expect(mockDataSources.ruralPaymentsCustomer.updatePersonDetails).toHaveBeenCalled()
+        expect(result).toEqual({
+          success: true,
+          customer: { personId: 'currentId' }
+        })
+      })
+
+      test('should not call validateEmail when the email is unchanged except for casing', async () => {
+        const input = { crn: 'crn', email: { address: mockPerson.email.toUpperCase() } }
+
+        await Mutation[mutationName](null, { input }, { dataSources: mockDataSources })
+
+        expect(mockDataSources.ruralPaymentsCustomer.validateEmail).not.toHaveBeenCalled()
+      })
+    }
+  )
 })

--- a/test/unit/resolvers/customer/customer-mutation.test.js
+++ b/test/unit/resolvers/customer/customer-mutation.test.js
@@ -154,23 +154,20 @@ describe('Customer Mutations', () => {
         )
       })
 
-      test('should not update the customer and should return emailDuplicated when the email is a duplicate', async () => {
+      test('should not update the customer and should throw when the email is a duplicate', async () => {
         const input = { crn: 'crn', email: { address: 'new@example.com' } }
 
         mockDataSources.ruralPaymentsCustomer.validateEmail.mockResolvedValue({
           emailDuplicated: true
         })
 
-        const result = await Mutation[mutationName](
-          null,
-          { input },
-          { dataSources: mockDataSources }
-        )
-
-        expect(result).toEqual({
-          success: false,
-          emailDuplicated: true
+        await expect(
+          Mutation[mutationName](null, { input }, { dataSources: mockDataSources })
+        ).rejects.toMatchObject({
+          message: 'Email address is already in use by another customer',
+          extensions: { code: 'EMAIL_ALREADY_REGISTERED', http: { status: 400 } }
         })
+
         expect(mockDataSources.ruralPaymentsCustomer.updatePersonDetails).not.toHaveBeenCalled()
       })
 


### PR DESCRIPTION
Added check to see if customer email is already registered to another customer during a customer email update

This fixes/resolves/relates to Jira ticket: [FCPDAL-122]


[FCPDAL-122]: https://eaflood.atlassian.net/browse/FCPDAL-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ