### PR TITLE
fix: remove seconds -> milliseconds conversion

### DIFF
--- a/app/transformers/rural-payments/customer.js
+++ b/app/transformers/rural-payments/customer.js
@@ -125,8 +125,7 @@ const customerUpdateInputMapping = {
   firstName: (input) => input.first,
   middleName: (input) => input.middle,
   lastName: (input) => input.last,
-  dateOfBirth: (input) =>
-    input.dateOfBirth && Math.floor(dob2utc(new Date(input.dateOfBirth).getTime()) / 1000),
+  dateOfBirth: (input) => input.dateOfBirth && dob2utc(Date.parse(input.dateOfBirth)),
   landline: (input) => input.phone?.landline,
   mobile: (input) => input.phone?.mobile,
   email: (input) => input.email?.address,
@@ -155,16 +154,6 @@ const customerUpdateInputMapping = {
 
 export function transformCustomerUpdateInputToPersonUpdate(person, input) {
   const mappedInput = transformMapping(customerUpdateInputMapping, input)
-
-  // Convert dateOfBirth from seconds (DAL) to milliseconds (stored format).
-  // The schema allows integer, string, or null; integers/strings may be negative (pre-1970).
-  const rawDob = person.dateOfBirth
-  if (rawDob != null) {
-    const milliseconds = Number(rawDob)
-    if (Number.isFinite(milliseconds)) {
-      person.dateOfBirth = Math.floor(milliseconds / 1000)
-    }
-  }
 
   return {
     ...person,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.27.0",
+      "version": "2.28.0",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/graphql/mutation/customer.test.js
+++ b/test/graphql/mutation/customer.test.js
@@ -37,7 +37,7 @@ function setupNock(update = {}) {
     firstName: 'currentFirstName',
     middleName: 'currentMiddleName',
     lastName: 'currentLastName',
-    dateOfBirth: 1735732800,
+    dateOfBirth: 1735732800000,
     landline: 'currentLandline',
     mobile: 'currentMobile',
     email: 'currentEmail',
@@ -68,11 +68,11 @@ function setupNock(update = {}) {
     _data: person
   })
 
-  // Update - nock expects the seconds value the resolver sends
+  // Update - nock expects the milliseconds value the resolver now sends
   const updatedPerson = {
     ...person,
     ...update,
-    dateOfBirth: update.dateOfBirth || 1735732,
+    dateOfBirth: update.dateOfBirth || 1735732800000,
     address: {
       ...person.address,
       ...(update?.address || {})
@@ -95,11 +95,7 @@ function setupNock(update = {}) {
   kits.get('/person/personId/summary').reply(200, {
     _data: {
       ...updatedPerson,
-      // Upstream receives the value in seconds, returns in milliseconds
-      dateOfBirth:
-        typeof updatedPerson.dateOfBirth === 'number'
-          ? updatedPerson.dateOfBirth * 1000
-          : updatedPerson.dateOfBirth
+      dateOfBirth: updatedPerson.dateOfBirth
     }
   })
 }
@@ -216,7 +212,7 @@ describe('customer mutations', () => {
 
   test('updateCustomerDateOfBirth', async () => {
     setupNock({
-      dateOfBirth: 1735689600
+      dateOfBirth: 1735689600000
     })
 
     const result = await makeTestQuery(`#graphql

--- a/test/unit/transformers/rural-payments/customer.test.js
+++ b/test/unit/transformers/rural-payments/customer.test.js
@@ -536,7 +536,7 @@ describe('Customer transformer', () => {
         firstName: 'newFirstName',
         middleName: 'newMiddleName',
         lastName: 'newLastName',
-        dateOfBirth: 1672617600, // seconds since epoch (transformer now outputs seconds)
+        dateOfBirth: 1672617600000,
         landline: 'newLandline',
         mobile: 'newMobile',
         email: 'newEmail',
@@ -569,7 +569,7 @@ describe('Customer transformer', () => {
         first: newPerson.firstName,
         middle: newPerson.middleName,
         last: newPerson.lastName,
-        dateOfBirth: '2023-01-02', // ISO date string (transformer converts to seconds)
+        dateOfBirth: '2023-01-02',
         doNotContact: newPerson.doNotContact,
         phone: {
           landline: newPerson.landline,
@@ -659,8 +659,7 @@ describe('Customer transformer', () => {
 
       const result = transformCustomerUpdateInputToPersonUpdate(currentPerson, input)
 
-      // seconds since epoch (upstream PUT expects seconds, not milliseconds)
-      expect(result).toEqual({ ...currentPerson, dateOfBirth: 1735689600 })
+      expect(result).toEqual({ ...currentPerson, dateOfBirth: 1735689600000 })
     })
 
     it('handles null values in input', () => {


### PR DESCRIPTION
The upstream does receive values in milliseconds, so no conversion is needed. The limit on the upstream is not accepting a timestamp that is in the future.

This fixes/resolves/relates to Jira ticket: [FCPDAL-482]


[FCPDAL-482]: https://eaflood.atlassian.net/browse/FCPDAL-482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ