### PR TITLE
Chore/unique dev build versions

### DIFF
--- a/.github/workflows/publish-dev-build.yml
+++ b/.github/workflows/publish-dev-build.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0 # Depth 0 is required for branch-based versioning
 
-      - name: Test code and Create Test Coverage Reports
+      - name: Test code
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/.github/workflows/publish-dev-build.yml
+++ b/.github/workflows/publish-dev-build.yml
@@ -1,0 +1,49 @@
+name: Publish Dev Build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+env:
+  AWS_REGION: eu-west-2
+  AWS_ACCOUNT_ID: '094954420758'
+
+jobs:
+  build:
+    name: CDP-build-dev-workflow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # Depth 0 is required for branch-based versioning
+
+      - name: Test code and Create Test Coverage Reports
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+      - run: |
+          npm audit --omit=dev
+          npm ci --ignore-scripts
+          npm run postinstall
+          npm run lint
+          npm test
+
+      - name: Publish Dev Build
+        uses: DEFRA/cdp-build-action/build-hotfix@f13fc42004f99a1df2e21ce1ff488cc72c897e40 # 17 Jul 2026
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          CUSTOM_TAG: 0.0.${{ github.run_number }}
+
+      # FIXME: this step should be run before the tag publishing in case there are problems found!
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0 # Depth 0 is required for branch-based versioning
 
-      - name: Test code and Create Test Coverage Reports
+      - name: Test code
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/README.md
+++ b/README.md
@@ -265,6 +265,18 @@ Modifications can be made by submitting a PR with changes to the relevant spec f
 The project is setup with SonarCloud to ensure certain important code quality standards are met.
 More information can be found [here](https://sonarcloud.io/project/overview?id=DEFRA_fcp-dal-api).
 
+### Publish Dev Build workflow
+
+The [`publish-dev-build`](./.github/workflows/publish-dev-build.yml) GitHub Actions workflow allows a build from any branch to be published to the `dev` environment ahead of merging to `main`, which is useful for testing changes before they are merged.
+
+For example, you might need to test logging works as expected within the cdp portal.
+
+It is triggered manually (`workflow_dispatch`) from the [Actions tab](https://github.com/DEFRA/fcp-dal-api/actions/workflows/publish-dev-build.yml) — select the branch to build from and run the workflow.
+
+The workflow publishes the build via [`cdp-build-action`](https://github.com/DEFRA/cdp-build-action)'s `build-hotfix` action, tagging it `0.0.<run_number>` (the GitHub Actions run number), so each dispatch of the workflow produces a unique, incrementing version regardless of branch.
+
+> NOTE: this bypasses the usual release process and is intended for short-lived dev testing only, not for tracking real releases.
+
 ### Dependabot - TODO!
 
 Decide whether to enable Depend-a-bot by renaming the [.github/example.dependabot.yml](.github/example.dependabot.yml) file to `.github/dependabot.yml` 🤷

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.28.0",
+      "version": "2.28.1",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",


### PR DESCRIPTION
 add support for publishing uniquely versioned dev builds to cdp with a purpose built publish-dev-build.yml workflow.
 
 Version number will be 0.0.github.run_number

This relates to Jira ticket: [FCPDAL-472]


[FCPDAL-472]: https://eaflood.atlassian.net/browse/FCPDAL-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ