### PR TITLE
fix: no auth header is needed on datasource construction - just when …

### DIFF
--- a/app/data-sources/rural-payments/RuralPayments.js
+++ b/app/data-sources/rural-payments/RuralPayments.js
@@ -66,6 +66,16 @@ export class RuralPayments extends BaseRESTDataSource {
       return
     }
 
+    if (!this.gatewayRoute) {
+      // No routing header was present when this datasource was constructed.  An upstream call will not be possible
+      throw new HttpError(StatusCodes.UNPROCESSABLE_ENTITY, {
+        extensions: {
+          message:
+            'Invalid request headers, must be either "email: {valid user email}", "service-account: {valid service account email}" or "X-Forwarded-Authorization: {defra-id token}" headers'
+        }
+      })
+    }
+
     const additionalHeaders = {}
 
     const internalEmail =
@@ -122,12 +132,10 @@ export class RuralPayments extends BaseRESTDataSource {
       this.gatewayRoute = 'external'
       authType = 'external'
     } else {
-      throw new HttpError(StatusCodes.UNPROCESSABLE_ENTITY, {
-        extensions: {
-          message:
-            'Invalid request headers, must be either "email: {valid user email}", "service-account: {valid service account email}" or "X-Forwarded-Authorization: {defra-id token}" headers'
-        }
-      })
+      // No routing header present. Upstream calls will not be possible, but this data source is constructed even
+      // for introspection queries - these do not require upstream calls.   Deferring any failures until auth is
+      // actually needed
+      authType = 'no-auth'
     }
 
     this.gatewayType = `rural-payments-${authType}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-dal-api",
-      "version": "2.31.0",
+      "version": "2.31.1",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-dal-api",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/acceptance/introspection.test.js
+++ b/test/acceptance/introspection.test.js
@@ -1,0 +1,18 @@
+import { GraphQLClient } from 'graphql-request'
+import { getIntrospectionQuery } from 'graphql'
+
+const targetURL = process.env.TARGET_URL ?? 'http://localhost:3000/graphql'
+
+describe('introspection query', () => {
+  it('succeeds with no email, service-account or x-forwarded-authorization headers set', async () => {
+    const client = new GraphQLClient(targetURL)
+
+    const response = await client.request(getIntrospectionQuery())
+
+    expect(response).not.toHaveProperty('errors')
+    expect(response.__schema.queryType.name).toBe('Query')
+    expect(response.__schema.types).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'Business' })])
+    )
+  })
+})

--- a/test/unit/data-sources/rural-payments/rural-payments.test.js
+++ b/test/unit/data-sources/rural-payments/rural-payments.test.js
@@ -202,20 +202,14 @@ describe('RuralPayments', () => {
       expect(rp.isExternalRoute()).toBe(false)
     })
 
-    test('throws if none of email, x-forwarded-authorization or service-account headers are present', () => {
-      try {
-        new RuralPayments({ logger }, { request: { headers: {} } })
-      } catch (thrownError) {
-        expect(thrownError).toBeInstanceOf(HttpError)
-        expect(thrownError.extensions).toMatchObject({
-          http: { status: StatusCodes.UNPROCESSABLE_ENTITY },
-          message:
-            'Invalid request headers, must be either "email: {valid user email}", "service-account: {valid service account email}" or "X-Forwarded-Authorization: {defra-id token}" headers'
-        })
-      }
+    test('does not throw when none of email, x-forwarded-authorization or service-account headers are present', () => {
+      // Constructing the datasource must not require a routing header - a request that never
+      // calls upstream (e.g. a pure introspection query) has no need for one. See willSendRequest
+      // below for the deferred throw that applies once an actual upstream call is attempted.
+      const rp = new RuralPayments({ logger }, { request: { headers: {} } })
 
-      // Ensure we actually ran the catch block assertions (i.e. the test did throw)
-      expect.assertions(2)
+      expect(rp.gatewayType).toBe('rural-payments-no-auth')
+      expect(rp.isExternalRoute()).toBe(false)
     })
   })
 
@@ -303,6 +297,26 @@ describe('RuralPayments', () => {
 
       await expect(rp.willSendRequest(path, request)).resolves.toBeUndefined()
       expect(request.headers).toEqual({})
+    })
+
+    test('throws when an upstream call is attempted with none of email, x-forwarded-authorization or service-account headers present', async () => {
+      const rp = new RuralPayments({ logger }, { request: { headers: {} } })
+      const request = { headers: {} }
+      const path = 'test-path'
+
+      try {
+        await rp.willSendRequest(path, request)
+      } catch (thrownError) {
+        expect(thrownError).toBeInstanceOf(HttpError)
+        expect(thrownError.extensions).toMatchObject({
+          http: { status: StatusCodes.UNPROCESSABLE_ENTITY },
+          message:
+            'Invalid request headers, must be either "email: {valid user email}", "service-account: {valid service account email}" or "X-Forwarded-Authorization: {defra-id token}" headers'
+        })
+      }
+
+      // Ensure we actually ran the catch block assertions (i.e. the test did throw)
+      expect.assertions(2)
     })
   })
 


### PR DESCRIPTION
The DAL service account change (version 1.17.0) introduced a regression issue, where the unauthenticated GraphQL introspection query (access via the GraphQL dashboard) no longer works, unless an email header is present on the request.

This happened as we no longer user the gatewayType header to identify the gateway route.  We now identify the route entirely by examining the type of upstream auth header supplied (email or defra id token).   This header used to only be used at the point of making an upstream call (where it would fail if no header was found).  It now fails on request initialisation, so requests that do not use the upstream (such as introspection) are now failing if no upstream auth header is present.

This PR addresses this issue.   Datasource construction not longer errors, deferring any errors to the first time that the datasource is used to call the upstream

This fixes to Jira ticket: [FCPDAL-515]


[FCPDAL-515]: https://eaflood.atlassian.net/browse/FCPDAL-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ